### PR TITLE
fix(flatpak): grant pipewire for preview

### DIFF
--- a/packaging/flatpak/com.gundulabs.Gaze.yml
+++ b/packaging/flatpak/com.gundulabs.Gaze.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
+  - --filesystem=xdg-run/pipewire-0
   - --system-talk-name=com.gundulabs.Gaze
   - --filesystem=xdg-run/gvfsd
   - --filesystem=xdg-run/gvfs:ro


### PR DESCRIPTION
The GUI's live RGB enrollment preview opens the camera via `pipewiresrc`, but the Flatpak sandbox granted no PipeWire access, so the preview stayed blank (the root daemon captures natively, outside the sandbox, so auth/enroll still worked). Grants the PipeWire socket via `--filesystem=xdg-run/pipewire-0`. Verified by rebuilding the Flatpak and confirming `pipewiresrc` prerolls inside the sandbox.