### PR TITLE
fix: stop lock-screen face auth from retrying forever

### DIFF
--- a/gnome-shell-extension/extension.js
+++ b/gnome-shell-extension/extension.js
@@ -228,8 +228,7 @@ export default class GazeFaceAuthExtension extends Extension {
         };
 
         proto._canFaceRetry = function () {
-            return this._userName &&
-                (this._reauthOnly || this._failCounter < (this._faceMaxTries ?? 1));
+            return this._userName && this._failCounter < (this._faceMaxTries ?? 1);
         };
 
         proto._getHint = function () {

--- a/pam-gaze-core/src/lib.rs
+++ b/pam-gaze-core/src/lib.rs
@@ -304,7 +304,13 @@ impl Drop for ReleaseGuard {
     }
 }
 
-pub async fn authenticate_biometric(username: &str) -> anyhow::Result<Option<bool>> {
+pub enum AuthOutcome {
+    Match,
+    NoMatch,
+    Unavailable,
+}
+
+pub async fn authenticate_biometric(username: &str) -> anyhow::Result<AuthOutcome> {
     let (_config, proxy) = setup_auth_env()
         .await
         .map_err(|e| anyhow::anyhow!("PAM error: {}", e))?;
@@ -319,8 +325,12 @@ pub async fn authenticate_biometric(username: &str) -> anyhow::Result<Option<boo
         active: true,
     };
 
-    let mut status_stream = proxy
+    let mut verify_stream = proxy
         .receive_verify_status()
+        .await
+        .map_err(|e| anyhow::anyhow!("Stream failed: {}", e))?;
+    let mut face_stream = proxy
+        .receive_face_status()
         .await
         .map_err(|e| anyhow::anyhow!("Stream failed: {}", e))?;
     proxy
@@ -328,23 +338,34 @@ pub async fn authenticate_biometric(username: &str) -> anyhow::Result<Option<boo
         .await
         .map_err(|e| anyhow::anyhow!("Verify start failed: {}", e))?;
 
-    let mut matched = false;
     use futures::StreamExt;
-    while let Some(signal) = status_stream.next().await {
-        if let Ok(args) = signal.args() {
-            match *args.result() {
-                gaze_core::dbus::VerifyResult::VerifyMatch => {
-                    matched = true;
-                    break;
+    let mut last_status: Option<gaze_core::dbus::CaptureStatus> = None;
+    let outcome = loop {
+        tokio::select! {
+            Some(signal) = verify_stream.next() => {
+                if let Ok(args) = signal.args() {
+                    match *args.result() {
+                        gaze_core::dbus::VerifyResult::VerifyMatch => break AuthOutcome::Match,
+                        gaze_core::dbus::VerifyResult::VerifyNoMatch => {
+                            break match last_status {
+                                Some(gaze_core::dbus::CaptureStatus::TooDark) => AuthOutcome::Unavailable,
+                                _ => AuthOutcome::NoMatch,
+                            };
+                        }
+                    }
                 }
-                gaze_core::dbus::VerifyResult::VerifyNoMatch => break,
+            }
+            Some(signal) = face_stream.next() => {
+                if let Ok(args) = signal.args() {
+                    last_status = Some(*args.status());
+                }
             }
         }
-    }
+    };
 
     guard.active = false;
     let _ = proxy.release().await;
-    Ok(Some(matched))
+    Ok(outcome)
 }
 
 pub fn get_user_uid(username: &str) -> Option<u32> {

--- a/pam-gaze-grosshack/src/lib.rs
+++ b/pam-gaze-grosshack/src/lib.rs
@@ -23,9 +23,8 @@ async fn authenticate_biometric_with_timeout(username: &str) -> Option<c_int> {
     tokio::select! {
         res = auth_future => {
             match res {
-                Ok(Some(true)) => Some(PAM_SUCCESS),
-                Ok(Some(false)) => Some(PAM_AUTH_ERR),
-                Ok(None) => Some(PAM_IGNORE),
+                Ok(AuthOutcome::Match) => Some(PAM_SUCCESS),
+                Ok(AuthOutcome::NoMatch) | Ok(AuthOutcome::Unavailable) => Some(PAM_AUTH_ERR),
                 Err(_) => None,
             }
         }

--- a/pam-gaze/src/lib.rs
+++ b/pam-gaze/src/lib.rs
@@ -27,9 +27,9 @@ unsafe fn do_authenticate(pamh: PamHandle) -> c_int {
         )
         .await
         {
-            Ok(Ok(Some(true))) => PAM_SUCCESS,
-            Ok(Ok(Some(false))) => PAM_AUTH_ERR,
-            Ok(Ok(None)) => PAM_IGNORE,
+            Ok(Ok(AuthOutcome::Match)) => PAM_SUCCESS,
+            Ok(Ok(AuthOutcome::NoMatch)) => PAM_AUTH_ERR,
+            Ok(Ok(AuthOutcome::Unavailable)) => PAM_AUTHINFO_UNAVAIL,
             _ => PAM_AUTHINFO_UNAVAIL,
         }
     })


### PR DESCRIPTION
On the GNOME lock screen the verifier runs in reauthOnly mode, so face auth retried forever instead of falling back to the password field.

- extension: cap face attempts at max-face-tries even in reauthOnly mode (drops the reauthOnly bypass in _canFaceRetry).
- pam: when the daemon gives up because the scene is too dark, return PAM_AUTHINFO_UNAVAIL instead of PAM_AUTH_ERR. GNOME marks the face service unavailable and stops retrying it (no point re-running a camera that can't see); other desktops/CLI get correct 'method unavailable, move on' semantics. The module learns it was dark from the daemon's existing TooDark face-status signal.