### PR TITLE
feat: logitech brio (046d:085e) IR emitter profile

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -137,6 +137,8 @@ ir = "pipewiresrc target-object=<pipewire-target>"
 
 When `ir` is configured, Gaze captures from both the RGB and IR cameras. During enrollment, both cameras will capture templates, and during verification, they will authenticate in parallel, combining results according to the configured `hybrid_policy`.
 
+> **Single-function cameras (e.g. Logitech BRIO, `046d:085e`):** some Windows Hello webcams expose their RGB and IR sensors as one USB Video Class function that cannot stream both substreams at once. Enrollment (short bursts) succeeds, but parallel RGB+IR verification drops the IR stream mid-loop (`IR camera stream stopped unexpectedly`) and auth falls back to password. On these devices, run IR-only: leave `rgb` unset (`rgb = ""`) and configure `ir` alone.
+
 ### IR emitter blaster
 
 Many IR cameras automatically light their infrared LED when streaming starts. If yours does not, set `emitter_enabled = true` to manually drive the emitter during authentication.

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -137,7 +137,9 @@ ir = "pipewiresrc target-object=<pipewire-target>"
 
 When `ir` is configured, Gaze captures from both the RGB and IR cameras. During enrollment, both cameras will capture templates, and during verification, they will authenticate in parallel, combining results according to the configured `hybrid_policy`.
 
-> **Single-function cameras (e.g. Logitech BRIO 4K, `046d:085e` — the original BRIO, not the newer Brio 300/500/100 which use different product IDs):** some Windows Hello webcams expose their RGB and IR sensors as one USB Video Class function that cannot stream both substreams at once. Enrollment (short bursts) succeeds, but parallel RGB+IR verification drops the IR stream mid-loop (`IR camera stream stopped unexpectedly`) and auth falls back to password. On these devices, run IR-only: leave `rgb` unset (`rgb = ""`) and configure `ir` alone.
+Some Windows Hello webcams expose their RGB and IR sensors as a single USB Video Class function and can't stream both at once. Enrollment still works since it only needs short bursts, but parallel RGB+IR verification drops the IR stream mid-loop (`IR camera stream stopped unexpectedly`) and auth falls back to password. If you hit this, run IR-only: leave `rgb` unset (`rgb = ""`) and configure `ir` alone.
+
+The Logitech BRIO 4K (`046d:085e`) is a known example. That's the original BRIO, not the newer Brio 300/500/100, which use different product IDs.
 
 ### IR emitter blaster
 

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -137,7 +137,7 @@ ir = "pipewiresrc target-object=<pipewire-target>"
 
 When `ir` is configured, Gaze captures from both the RGB and IR cameras. During enrollment, both cameras will capture templates, and during verification, they will authenticate in parallel, combining results according to the configured `hybrid_policy`.
 
-> **Single-function cameras (e.g. Logitech BRIO, `046d:085e`):** some Windows Hello webcams expose their RGB and IR sensors as one USB Video Class function that cannot stream both substreams at once. Enrollment (short bursts) succeeds, but parallel RGB+IR verification drops the IR stream mid-loop (`IR camera stream stopped unexpectedly`) and auth falls back to password. On these devices, run IR-only: leave `rgb` unset (`rgb = ""`) and configure `ir` alone.
+> **Single-function cameras (e.g. Logitech BRIO 4K, `046d:085e` — the original BRIO, not the newer Brio 300/500/100 which use different product IDs):** some Windows Hello webcams expose their RGB and IR sensors as one USB Video Class function that cannot stream both substreams at once. Enrollment (short bursts) succeeds, but parallel RGB+IR verification drops the IR stream mid-loop (`IR camera stream stopped unexpectedly`) and auth falls back to password. On these devices, run IR-only: leave `rgb` unset (`rgb = ""`) and configure `ir` alone.
 
 ### IR emitter blaster
 

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -125,8 +125,9 @@ undistorted frames as well as freshly enrolled ones.
 
 ### Auth aborts with "IR camera stream stopped unexpectedly"
 
-Some single-function Windows Hello webcams (for example the Logitech BRIO,
-`046d:085e`) cannot stream their RGB and IR sensors simultaneously. Enrollment
+Some single-function Windows Hello webcams (for example the Logitech BRIO 4K,
+`046d:085e` — the original BRIO, distinct from the newer Brio 300/500/100 which
+use different product IDs) cannot stream their RGB and IR sensors simultaneously. Enrollment
 works, but parallel RGB+IR verification drops the IR substream and the attempt
 falls back to your password. Configure the IR camera on its own and leave `rgb`
 empty so Gaze runs IR-only:

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -125,12 +125,12 @@ undistorted frames as well as freshly enrolled ones.
 
 ### Auth aborts with "IR camera stream stopped unexpectedly"
 
-Some single-function Windows Hello webcams (for example the Logitech BRIO 4K,
-`046d:085e` — the original BRIO, distinct from the newer Brio 300/500/100 which
-use different product IDs) cannot stream their RGB and IR sensors simultaneously. Enrollment
-works, but parallel RGB+IR verification drops the IR substream and the attempt
-falls back to your password. Configure the IR camera on its own and leave `rgb`
-empty so Gaze runs IR-only:
+Some single-function Windows Hello webcams can't stream their RGB and IR sensors
+at the same time. The Logitech BRIO 4K (`046d:085e`, not the newer Brio
+300/500/100, which use different product IDs) is a known example. Enrollment
+works fine, but parallel RGB+IR verification drops the IR substream and the
+attempt falls back to your password. Configure the IR camera on its own and
+leave `rgb` empty so Gaze runs IR-only:
 
 ```toml
 [cameras]

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -123,6 +123,21 @@ widescreen (16:9) camera, re-enroll your faces once: older releases stretched
 widescreen frames to 4:3, so templates enrolled before the fix will not match
 undistorted frames as well as freshly enrolled ones.
 
+### Auth aborts with "IR camera stream stopped unexpectedly"
+
+Some single-function Windows Hello webcams (for example the Logitech BRIO,
+`046d:085e`) cannot stream their RGB and IR sensors simultaneously. Enrollment
+works, but parallel RGB+IR verification drops the IR substream and the attempt
+falls back to your password. Configure the IR camera on its own and leave `rgb`
+empty so Gaze runs IR-only:
+
+```toml
+[cameras]
+rgb = ""
+ir = "/dev/video2"
+emitter_enabled = true
+```
+
 ## 4. Lock screen does not trigger face auth
 
 Enable or re-enable the extension from your GNOME session:

--- a/gaze-core/ir-profiles/046d-085e.toml
+++ b/gaze-core/ir-profiles/046d-085e.toml
@@ -1,3 +1,8 @@
+# NOTE: The BRIO is a single-function UVC device and cannot stream its RGB
+# (/dev/video0) and IR (/dev/video2) sensors simultaneously. Run IR-only
+# (leave [cameras] rgb empty) or parallel verification will drop the IR
+# stream. See docs/src/guide/troubleshooting.md.
+
 [device]
 vendor_id  = 0x046D
 product_id = 0x085E

--- a/gaze-core/ir-profiles/046d-085e.toml
+++ b/gaze-core/ir-profiles/046d-085e.toml
@@ -1,0 +1,11 @@
+[device]
+vendor_id  = 0x046D
+product_id = 0x085E
+name       = "Logitech BRIO (BRIO 4K Pro) IR emitter"
+source     = "Empirically probed on Arch/CachyOS 2026-07-14: extension unit 12, selector 0x06, 9-byte control. Values follow the [1, iface, mode, 0..] Windows-Hello face-auth shape but with iface byte = 2 (not the more common 3) and inverted mode semantics: mode 1 = emitter ON (IR frame mean luma ~39/max 227), mode 2 = OFF (dark). Verified by toggling GET_CUR/SET_CUR while capturing /dev/video2."
+
+[emitter]
+unit              = 12
+selector          = 0x06
+control_bytes     = [0x01, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]  # ON
+off_control_bytes = [0x01, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]  # OFF

--- a/gaze-core/ir-profiles/046d-085e.toml
+++ b/gaze-core/ir-profiles/046d-085e.toml
@@ -1,12 +1,17 @@
-# NOTE: The BRIO is a single-function UVC device and cannot stream its RGB
-# (/dev/video0) and IR (/dev/video2) sensors simultaneously. Run IR-only
-# (leave [cameras] rgb empty) or parallel verification will drop the IR
-# stream. See docs/src/guide/troubleshooting.md.
+# Scope: matches USB 046d:085e only — the original Logitech BRIO 4K family
+# (BRIO Ultra HD Webcam / BRIO 4K Pro / BRIO 4K Stream Edition; identical
+# hardware). The newer Brio 300 / 500 / 100 report different product IDs and
+# are NOT covered by this profile; they would each need their own.
+#
+# NOTE: The BRIO 4K (046d:085e) is a single-function UVC device and cannot
+# stream its RGB (/dev/video0) and IR (/dev/video2) sensors simultaneously.
+# Run IR-only (leave [cameras] rgb empty) or parallel verification will drop
+# the IR stream. See docs/src/guide/troubleshooting.md.
 
 [device]
 vendor_id  = 0x046D
 product_id = 0x085E
-name       = "Logitech BRIO (BRIO 4K Pro) IR emitter"
+name       = "Logitech BRIO 4K (046d:085e) IR emitter"
 source     = "Empirically probed on Arch/CachyOS 2026-07-14: extension unit 12, selector 0x06, 9-byte control. Values follow the [1, iface, mode, 0..] Windows-Hello face-auth shape but with iface byte = 2 (not the more common 3) and inverted mode semantics: mode 1 = emitter ON (IR frame mean luma ~39/max 227), mode 2 = OFF (dark). Verified by toggling GET_CUR/SET_CUR while capturing /dev/video2."
 
 [emitter]


### PR DESCRIPTION
Adds a static IR emitter profile for the **Logitech BRIO / BRIO 4K Pro** (`046d:085e`), a Windows-Hello IR webcam whose IR sensor enumerates as a 340×340 `GREY` node.

## Problem
On the BRIO, `emitter_enabled = true` still logged:

```
no IR emitter profile for /dev/video2; continuing without illumination
```

…and IR frames came back dark (mean luma ~3), so enrollment/auth fell back to RGB only.

The BRIO *does* expose a face-auth-style UVC extension-unit control, but `cached_face_auth_profile` skips it: the control is on **unit 12, selector 0x06** with a 9-byte payload of the familiar `[1, iface, mode, 0..]` shape — but `iface = 2` (not `3`), and the mode semantics are **inverted** (`mode 1 = ON`, `mode 2 = OFF`). Since it does not match the `[1, 3, mode, ..]` / `looks_like_face_auth_control` pattern, no runtime profile is derived.

## Fix
A static profile encoding the empirically-verified sequences:

| | unit | selector | payload |
|---|---|---|---|
| ON | 12 | 0x06 | `01 02 01 00 00 00 00 00 00` |
| OFF | 12 | 0x06 | `01 02 02 00 00 00 00 00 00` |

## How the values were found
Toggling `GET_CUR`/`SET_CUR` on unit 12 / selector 0x06 while sampling `/dev/video2`:

- `mode 1` → lit IR frame (mean luma **~39**, max **227**)
- `mode 2` / `mode 3` → dark (mean <2)

## Testing
Built from source against OpenCV 5 (`OPENCV_PKGCONFIG_NAME=opencv5`, per #220) on Arch/CachyOS, kernel 6.x. With the profile present, the daemon no longer logs the illumination warning and enrollment captures both templates:

```
default  [RGB] [IR]  (10 captures)
```

Hardware: Logitech BRIO `046d:085e`, KDE Plasma (Wayland), PipeWire RGB + direct `/dev/video2` IR.

---

### Update: BRIO cannot dual-stream RGB+IR (docs added)

While validating on hardware I hit a second BRIO-specific gotcha worth capturing here: the BRIO is a **single-function UVC device and cannot stream its RGB (`/dev/video0`) and IR (`/dev/video2`) sensors simultaneously.** Enrollment (short bursts) works, but parallel RGB+IR *verification* drops the IR substream mid-loop:

```
gaze_core::camera: Camera stream ended (EOS)
gazed::daemon: VerifyStart loop error: IR camera stream stopped unexpectedly
```

…and auth then falls back to password. The fix is to run **IR-only** (`[cameras] rgb = ""`), which also gives a cleaner Windows-Hello-style secure config. With `rgb` empty, verification is stable (IR similarity 0.87, ~1.4 s).

This PR now also documents that limitation:
- a comment in `046d-085e.toml`
- a note in the IR camera section of `configuration.md`
- a troubleshooting entry for `IR camera stream stopped unexpectedly`