### PR TITLE
fix: serialize rgb/ir camera use in verify

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -135,7 +135,7 @@ You can also use an IR PipeWire/GStreamer source:
 ir = "pipewiresrc target-object=<pipewire-target>"
 ```
 
-When `ir` is configured, Gaze captures from both the RGB and IR cameras. During enrollment, both cameras will capture templates, and during verification, they will authenticate in parallel, combining results according to the configured `hybrid_policy`.
+When `ir` is configured, Gaze captures from both the RGB and IR cameras. During enrollment, both cameras capture templates. During verification, Gaze captures from the two cameras one at a time (RGB, then IR) and combines the results according to the configured `hybrid_policy`. Capturing sequentially rather than concurrently lets single-function webcams that cannot stream their RGB and IR sensors at once (for example the Logitech BRIO 4K, `046d:085e`) still use hybrid authentication.
 
 ### IR emitter blaster
 

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -35,6 +35,11 @@ const GDM_DCONF_OVERRIDE_CONTENT: &str =
     "[org/gnome/shell/extensions/gaze]\nenable-face-authentication=true\n";
 const CLAIM_TIMEOUT_SECS: u64 = 300;
 const VERIFY_TOO_DARK_TIMEOUT: Duration = Duration::from_secs(1);
+/// In hybrid (RGB+IR) verify the two spectra are captured one camera at a time so
+/// single-function UVC devices (e.g. Logitech Brio) that cannot stream both at once
+/// still work. This bounds the RGB phase so it yields the camera to IR even without a
+/// match. See `verify_start`.
+const VERIFY_SERIAL_RGB_BUDGET: Duration = Duration::from_secs(4);
 const SSH_PROC_CHAIN_MAX_DEPTH: usize = 16;
 
 #[derive(Clone)]
@@ -1526,6 +1531,10 @@ impl AuthDaemon {
 
             let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<VerifyMsg>(10);
             let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            // Signals that the RGB capture phase has finished and released its camera, so
+            // the IR thread can then hold the camera. Lets single-function UVC devices
+            // (e.g. Logitech Brio) that cannot stream RGB+IR at once run hybrid verify.
+            let rgb_phase_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
             let mut rgb_thread = None;
             if run_rgb {
@@ -1541,8 +1550,24 @@ impl AuthDaemon {
                 let liveness_enabled = liveness_cfg.enabled;
                 let liveness_threshold = liveness_cfg.threshold;
                 let rgb_device_clone = rgb_device.clone();
+                let rgb_phase_done_clone = rgb_phase_done.clone();
 
                 rgb_thread = Some(std::thread::spawn(move || {
+                    // Set once the RGB camera is released, on every exit path (incl. panic),
+                    // so the IR thread can then safely open its stream. Declared before `cam`
+                    // so `cam` drops first, guaranteeing release precedes the signal.
+                    struct RgbPhaseGuard(Arc<std::sync::atomic::AtomicBool>);
+                    impl Drop for RgbPhaseGuard {
+                        fn drop(&mut self) {
+                            self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    }
+                    let _rgb_phase_guard = RgbPhaseGuard(rgb_phase_done_clone);
+                    // In serial mode (IR also runs) yield the camera after a budget even
+                    // without a match, so the IR spectrum can still be captured.
+                    let rgb_deadline = run_ir.then(|| Instant::now() + VERIFY_SERIAL_RGB_BUDGET);
+                    let mut yielded_to_ir = false;
+
                     let mut cam = match Camera::open(&rgb_device_clone) {
                         Ok(c) => c,
                         Err(e) => {
@@ -1558,6 +1583,14 @@ impl AuthDaemon {
 
                     for frame in &mut cam {
                         if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                            break;
+                        }
+                        if let Some(deadline) = rgb_deadline
+                            && Instant::now() >= deadline
+                        {
+                            // Serial mode: hand the camera to the IR phase even without a
+                            // match so hybrid auth can still capture the IR spectrum.
+                            yielded_to_ir = true;
                             break;
                         }
 
@@ -1639,7 +1672,7 @@ impl AuthDaemon {
                         }
                     }
 
-                    if !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                    if !yielded_to_ir && !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                         let _ = tx.blocking_send(VerifyMsg::Error(
                             "RGB camera stream stopped unexpectedly".into(),
                         ));
@@ -1648,12 +1681,7 @@ impl AuthDaemon {
             }
 
             let mut ir_thread = None;
-                // If RGB is also running, introduce a short delay to ensure RGB gets the head start on PipeWire/USB resource access.
             if run_ir {
-                if run_rgb {
-                    std::thread::sleep(std::time::Duration::from_millis(2));
-                }
-
                 let stop_clone = stop_flag.clone();
                 let tx = result_tx.clone();
                 let detector_arc = detector_arc.clone();
@@ -1666,8 +1694,23 @@ impl AuthDaemon {
                 let ir_device_clone = ir_device.clone();
                 let ir_node_clone = ir_node.clone();
                 let emitter_enabled = emitter_enabled;
+                let rgb_phase_done_clone = rgb_phase_done.clone();
 
                 ir_thread = Some(std::thread::spawn(move || {
+                    // Serial mode: wait for the RGB phase to release its camera before
+                    // opening IR (and firing the emitter), so only one stream is live at a
+                    // time on single-function UVC devices. Bail if verify already passed.
+                    if run_rgb {
+                        while !rgb_phase_done_clone.load(std::sync::atomic::Ordering::Relaxed)
+                            && !stop_clone.load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            std::thread::sleep(std::time::Duration::from_millis(20));
+                        }
+                        if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                            return;
+                        }
+                    }
+
                     let _emitter = EmitterGuard::engage(
                         &CameraKind::Ir { source: ir_device_clone.clone(), node: ir_node_clone.clone() },
                         emitter_enabled


### PR DESCRIPTION
## Problem

Single-function UVC devices (e.g. Logitech Brio 4K) cannot stream the RGB (`/dev/video0`) and IR (`/dev/video2`) sensors concurrently. #250 fixed this for **enroll** by holding one camera at a time, but the **verify** path still spawned its RGB and IR capture threads in parallel. On these devices the IR substream EOSes mid-loop (`IR camera stream stopped unexpectedly`) and hybrid (RGB+IR) verify aborts — so `hybrid_policy = and`/`or`/`fallback_on_dark` never works on a Brio, even with both spectra enrolled.

This is the verify-side counterpart to #250 (which closed #244).

## Change

Serialize the two capture threads in `verify_start` whenever both spectra run:

- The RGB thread signals completion via a shared `rgb_phase_done` flag, set by a `Drop` guard **after** the camera is released, on every exit path (match, error, stream end, panic).
- A wall-clock budget (`VERIFY_SERIAL_RGB_BUDGET`, 4s) lets the RGB phase yield the camera to IR even without a match, so hybrid auth can still capture the IR spectrum.
- The IR thread waits on `rgb_phase_done` before engaging the emitter and opening its stream; it bails early if verify already passed (e.g. `or` matched on RGB alone — IR never opens, emitter never fires).

Only one camera is ever open at a time. The order-independent hybrid combine (`hybrid_auth_passed`) and the message-collection loop are unchanged; single-spectrum verify is unaffected (keeps the unbounded loop, no latency change).

## Testing

- `cargo test -p gaze` (hybrid_auth_passed unit tests) green.
- Hardware-validated on a Logitech Brio 4K (`046d:085e`), CachyOS/KDE Wayland, with an IR-emitter profile for the device:
  - `hybrid_policy = and`: RGB then IR captured sequentially, no stream drop, match requires both spectra. ✅
  - `hybrid_policy = or`: RGB match alone completes; IR/emitter never engage. ✅
  - IR-only config unchanged (~0.56s baseline). ✅

The concurrency/camera path isn't unit-testable, so it's verified manually on hardware.
