### PR TITLE
feat(installer): support Fedora-compatible distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ flatpak-build/
 node_modules/
 docs/.vitepress/dist
 docs/.vitepress/cache
+docs/.vitepress/.temp
 
 dist/
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ gsettings set org.gnome.shell.extensions.gaze enable-face-authentication true
 > Running `gnome-extensions enable` before rebooting will return `Extension "gaze@gundulabs.com" does not exist`. Shell only rescans extension directories at session start.
 
 <details>
-<summary>Manual install (Debian/Ubuntu, Fedora, Arch/Manjaro/CachyOS)</summary>
+<summary>Manual install (Debian/Ubuntu, Fedora and compatible DNF systems, Arch/Manjaro/CachyOS)</summary>
 
 **Debian / Ubuntu**
 
@@ -50,7 +50,7 @@ sudo apt update
 sudo apt install gaze gaze-gui
 ```
 
-**Fedora**
+**Fedora and compatible DNF systems**
 
 ```bash
 sudo rpm --import https://packages.gundulabs.com/keys/gundulabs-repo.asc

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -408,8 +408,15 @@ DISTRO_VERSION_ID="${VERSION_ID:-}"
 DISTRO_CODENAME="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
 VARIANT_ID="${VARIANT_ID:-}"
 
-is_fedora() {
-    [ "$DISTRO_ID" = "fedora" ]
+is_fedora_compatible() {
+    case " $DISTRO_ID $DISTRO_LIKE " in
+    *" fedora "*) return 0 ;;
+    esac
+    return 1
+}
+
+is_ostree_system() {
+    [ -e /run/ostree-booted ]
 }
 
 is_rpm() {
@@ -440,7 +447,7 @@ supported_deb_suite() {
     return 1
 }
 
-supported_fedora_version() {
+supported_fedora_compatible_version() {
     case "$DISTRO_VERSION_ID" in
     42 | 43 | 44) return 0 ;;
     esac
@@ -449,7 +456,7 @@ supported_fedora_version() {
 
 if ! is_rpm && ! is_deb && ! is_arch; then
     fail "Unsupported distribution: $DISTRO_ID"
-    say "Supported: Ubuntu 24.04/25.10/26.04, Debian 13, Fedora 42/43/44, Arch Linux, and Arch-compatible AUR distros"
+    say "Supported: Ubuntu 24.04/25.10/26.04, Debian 13, Fedora-compatible 42/43/44 systems with standard DNF package installation, Arch Linux, and Arch-compatible AUR distros"
     exit 1
 fi
 
@@ -468,15 +475,22 @@ if is_deb && ! supported_deb_suite "$DISTRO_CODENAME"; then
     exit 1
 fi
 
-if is_rpm && ! is_fedora; then
-    fail "Unsupported RPM distribution: $DISTRO_ID"
-    say "Supported RPM distribution: Fedora"
+if is_rpm && ! is_fedora_compatible; then
+    fail "Unsupported RPM distribution: ${NAME:-$DISTRO_ID}"
+    say "This installer supports RPM distributions that identify as Fedora-compatible in /etc/os-release."
     exit 1
 fi
 
-if is_fedora && ! supported_fedora_version; then
-    fail "Unsupported Fedora version: ${DISTRO_VERSION_ID:-unknown}"
-    say "Supported Fedora versions: 42, 43, 44"
+if is_fedora_compatible && is_ostree_system; then
+    fail "Image-based Fedora-compatible system detected: ${NAME:-$DISTRO_ID}"
+    say "This installer currently supports systems that install packages directly with DNF (also called mutable or non-image-based systems)."
+    say "Systems that use rpm-ostree, such as Bazzite, Fedora Silverblue, and Fedora Kinoite, are not yet supported."
+    exit 1
+fi
+
+if is_fedora_compatible && ! supported_fedora_compatible_version; then
+    fail "Unsupported ${NAME:-Fedora-compatible distribution} version: ${DISTRO_VERSION_ID:-unknown}"
+    say "Fedora-compatible packages are currently available for versions 42, 43, and 44."
     exit 1
 fi
 
@@ -509,7 +523,7 @@ elif is_rpm; then
     else
         RPM_TOOL="yum"
     fi
-    say "Detected platform: ${BOLD}Fedora ${DISTRO_VERSION_ID}${RESET} (${PKG_ARCH}), package manager: ${RPM_TOOL}"
+    say "Detected platform: ${BOLD}${NAME:-Fedora} ${DISTRO_VERSION_ID}${RESET} (${PKG_ARCH}), package manager: ${RPM_TOOL}"
     STEP_TOTAL=6
     echo ""
     title "This will:"

--- a/docs/src/guide/hyprland.md
+++ b/docs/src/guide/hyprland.md
@@ -16,7 +16,7 @@ Manual install:
 sudo apt-get install gaze-hyprlock
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo dnf install gaze-hyprlock
 ```
 
@@ -82,7 +82,7 @@ Remove the `module` line from the `auth { pam { ... } }` block in `hyprlock.conf
 sudo apt-get remove gaze-hyprlock
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo dnf remove gaze-hyprlock
 ```
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -2,7 +2,7 @@
 
 Use one of these paths. The one-line installer enables GNOME lock screen auth for the current GNOME user when possible, and skips GNOME-specific packages on KDE Plasma and other non-GNOME desktops. Manual GNOME package installs still need GNOME settings commands afterward.
 
-Supported installer targets: Ubuntu 24.04/25.10/26.04, Debian 13, Fedora 42/43/44, Arch Linux, and Arch-compatible AUR distributions such as Manjaro and CachyOS, on x86_64 and arm64.
+Supported installer targets on x86_64 and arm64: Ubuntu 24.04/25.10/26.04, Debian 13, Fedora 42/43/44 and compatible distributions with standard DNF package installation, such as Nobara and Ultramarine, Arch Linux, and Arch-compatible AUR distributions such as Manjaro and CachyOS.
 
 ## Path A: one-line installer (recommended)
 
@@ -33,7 +33,7 @@ curl -fsSL https://gaze.gundulabs.com/install.sh | sh -s -- --yes
 
 ## Path B: manual package install
 
-Use this if you prefer to configure package sources yourself. Debian/Ubuntu and Fedora use Gundu Labs repositories. Arch Linux and Arch-compatible distributions such as Manjaro and CachyOS use the AUR packages.
+Use this if you prefer to configure package sources yourself. Debian/Ubuntu and Fedora-compatible systems with standard DNF package installation use Gundu Labs repositories. Arch Linux and Arch-compatible distributions such as Manjaro and CachyOS use the AUR packages.
 
 If you are replacing an existing manual repository configuration, remove the current repo files first:
 
@@ -42,7 +42,7 @@ If you are replacing an existing manual repository configuration, remove the cur
 sudo rm -f /etc/apt/sources.list.d/gundulabs.list /usr/share/keyrings/gundulabs-archive-keyring.gpg
 ```
 
-**Fedora:**
+**Fedora and compatible DNF systems:**
 ```bash
 sudo rm -f /etc/yum.repos.d/gundulabs.repo /etc/pki/rpm-gpg/RPM-GPG-KEY-gundulabs
 ```
@@ -59,7 +59,7 @@ sudo apt update
 sudo apt install gaze gaze-gui
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo rpm --import https://packages.gundulabs.com/keys/gundulabs-repo.asc
 sudo tee /etc/yum.repos.d/gundulabs.repo >/dev/null <<'EOF'
 [gundulabs]
@@ -103,7 +103,7 @@ Only run this on GNOME desktops where you want face unlock from the lock screen.
 sudo apt install gaze-gnome-extension
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo dnf install gaze-gnome-extension
 ```
 

--- a/docs/src/guide/pam.md
+++ b/docs/src/guide/pam.md
@@ -32,11 +32,13 @@ sudo -v
 
 If camera opens and face auth runs, PAM wiring is active.
 
-## Fedora / RPM systems
+## Fedora and compatible RPM systems
 
 RPM packages install an authselect profile at:
 
 `/usr/share/authselect/vendor/gaze`
+
+The profile adds Gaze to both shared authentication stacks: `system-auth`, used by tools such as `sudo`, and `password-auth`, used by KDE's lock screen, SDDM, and Plasma Login Manager. RPM upgrades refresh these generated PAM files automatically when the Gaze profile is active.
 
 Enable it:
 

--- a/docs/src/guide/uninstallation.md
+++ b/docs/src/guide/uninstallation.md
@@ -54,7 +54,7 @@ sudo dconf update
 sudo pam-auth-update --package --remove gaze
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 if [ -f /etc/gaze/authselect.previous ]; then
   profile=$(sudo sed -n 's/^Profile ID:[[:space:]]*//p' /etc/gaze/authselect.previous)
   features=$(sudo sed -n 's/^- //p' /etc/gaze/authselect.previous | tr '\n' ' ')
@@ -92,7 +92,7 @@ sudo apt remove --purge gaze gaze-gui gaze-gnome-extension gaze-hyprlock
 sudo apt autoremove
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo dnf remove gaze gaze-gui gaze-gnome-extension gaze-hyprlock
 ```
 
@@ -118,7 +118,7 @@ sudo rm /usr/share/keyrings/gundulabs-archive-keyring.gpg
 sudo apt update
 ```
 
-```bash [Fedora]
+```bash [Fedora and compatible]
 sudo rm /etc/yum.repos.d/gundulabs.repo
 sudo rpm -e gpg-pubkey-$(rpm -qa gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -i gundulabs | awk '{print $1}' | sed 's/gpg-pubkey-//')
 sudo dnf makecache

--- a/packaging/authselect/custom/gaze/README
+++ b/packaging/authselect/custom/gaze/README
@@ -1,14 +1,14 @@
 Local users only (with Gaze Facial Authentication)
 ================
 
-Selecting this profile will enable local files as the source of identity
-and authentication providers. It includes Gaze facial authentication by default.
+Selecting this profile uses local files for identity and authentication and
+enables Gaze facial authentication by default.
 
 AVAILABLE OPTIONAL FEATURES
 ---------------------------
 
 with-face-simultaneous::
-    Attempts facial authentication simultaneously with password prompt
+    Attempts facial authentication simultaneously with the password prompt.
 
 with-faillock::
     Enable account locking in case of too many consecutive

--- a/packaging/authselect/custom/gaze/password-auth
+++ b/packaging/authselect/custom/gaze/password-auth
@@ -3,6 +3,8 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_gaze_grosshack.so                                  {include if "with-face-simultaneous"}
+auth        sufficient                                   pam_gaze.so                                            {exclude if "with-face-simultaneous"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}

--- a/packaging/postinst-rpm.sh
+++ b/packaging/postinst-rpm.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+# Regenerate PAM files after a Gaze profile update, but only when Gaze is
+# already selected. Never replace another active authselect profile.
+if command -v authselect >/dev/null 2>&1 &&
+	authselect current --raw 2>/dev/null | grep -q '^gaze\([[:space:]]\|$\)'; then
+	authselect apply-changes >/dev/null 2>&1 || true
+fi
+
 if [ -d /run/systemd/system ]; then
 	systemctl daemon-reload >/dev/null 2>&1
 	dbus-send --system --type=method_call --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.ReloadConfig >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

This PR extends the installer’s Fedora support to compatible distributions such as Nobara and Ultramarine, using both `ID` and `ID_LIKE` from `/etc/os-release`.

It also adds Gaze to the authselect `password-auth` template. This enables face authentication for applications that use `password-auth`, including KDE Plasma’s lock screen, SDDM, and Plasma Login Manager.

## Changes

- Generalize Fedora detection to Fedora-compatible distributions.
- Accept supported Fedora versions when `ID_LIKE` contains `fedora`.
- Detect and reject image-based/rpm-ostree systems with a clear explanation instead of attempting a DNF installation.
- Add the standard and simultaneous Gaze PAM modules to `password-auth`.
- Regenerate PAM files after RPM upgrades when the Gaze authselect profile is already active.
- Leave non-Gaze authselect profiles unchanged.
- Update installation, PAM, Hyprland, and uninstallation documentation.
- Ignore VitePress’s generated `.temp` directory.

## Testing

- Verified installer detection on Nobara Linux 44.
- Checked installer and packaging scripts for POSIX shell syntax errors.
- Verified both standard and simultaneous authselect configurations on Fedora 44.
- Verified RPM post-install regeneration for an active Gaze profile.
- Verified that non-Gaze authselect profiles are not modified.
- Built the VitePress documentation successfully.

## Notes

Image-based Fedora variants such as Bazzite, Fedora Silverblue, and Fedora Kinoite remain unsupported because they use rpm-ostree rather than the standard mutable DNF workflow.