### PR TITLE
feat: configure enrollment face size threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ abort_if_lid_closed = true
 
 [enrollment]
 max_templates = 2
+min_face_size_ratio = 0.25
 
 [liveness]
 enabled = true

--- a/docs/src/guide/cli.md
+++ b/docs/src/guide/cli.md
@@ -141,7 +141,7 @@ Show-only mode:
 gaze config --show
 ```
 
-Prints all current config values (security level, detector and recognizer model, threshold, camera sources, emitter state, dark-frame threshold, auth behavior, hybrid combining policy, enrollment limit, and liveness settings) without opening the editor.
+Prints all current config values (security level, detector and recognizer model, threshold, camera sources, emitter state, dark-frame threshold, auth behavior, hybrid combining policy, enrollment limit and minimum face-size ratio, and liveness settings) without opening the editor.
 
 ## Manage another user
 

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -32,6 +32,7 @@ resume_grace_ms = 0
 
 [enrollment]
 max_templates = 2
+min_face_size_ratio = 0.25
 
 [liveness]
 enabled = true
@@ -244,9 +245,20 @@ sudo systemctl restart gazed
 ```toml
 [enrollment]
 max_templates = 2
+min_face_size_ratio = 0.25
 ```
 
-Increase this if auth is unreliable in varied lighting.
+Increase `max_templates` if auth is unreliable in varied lighting.
+
+`min_face_size_ratio` controls the smallest detected face accepted during enrollment,
+as a fraction of the frame's shorter side. The default `0.25` requires the face to
+occupy at least one quarter of that dimension. Lowering it permits enrollment from
+farther away; for example, `0.20` permits a face roughly 25% farther away than the
+default. Values from `0.10` through `0.75` are accepted.
+
+This is an enrollment-quality gate only; authentication does not impose the same
+centering and proximity threshold. Use the highest value that remains comfortable,
+because smaller face crops contain less detail for the enrolled template.
 
 ### Multi-Camera & Hybrid Enrollment
 

--- a/docs/src/guide/gui.md
+++ b/docs/src/guide/gui.md
@@ -25,6 +25,7 @@ From there you can edit:
 - RGB camera source, IR camera device, and IR emitter
 - Dark-frame rejection cutoff
 - Maximum enrollment templates per face
+- Minimum enrollment face-size ratio (lower values allow enrollment from farther away)
 - Liveness anti-spoofing (enable, threshold, max frames)
 - Auth behavior (abort if SSH, abort if lid closed, require confirmation)
 

--- a/gaze-cli/src/doctor.rs
+++ b/gaze-cli/src/doctor.rs
@@ -301,6 +301,12 @@ fn config_findings(config: &Config) -> Vec<Check> {
             "Choose a supported security level with `gaze config`.",
         );
     }
+    if let Err(err) = config.enrollment.validate() {
+        error(
+            err.to_string(),
+            "Set enrollment.min_face_size_ratio to a value from 0.10 through 0.75.",
+        );
+    }
 
     if config.security.level == "custom" {
         if !config.security.threshold.is_finite()
@@ -1024,6 +1030,7 @@ mod tests {
         config.security.threshold = 1.5;
         config.security.hybrid_policy = "sometimes".to_string();
         config.cameras.rgb = "/dev/video0".to_string();
+        config.enrollment.min_face_size_ratio = 0.05;
         config.liveness.threshold = f64::NAN;
         config.liveness.max_frames = 0;
 
@@ -1046,6 +1053,11 @@ mod tests {
             messages
                 .iter()
                 .any(|message| message.contains("direct RGB"))
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("enrollment.min_face_size_ratio"))
         );
         assert!(
             messages

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -349,6 +349,11 @@ async fn run_config_wizard(
         .default(config.enrollment.max_templates)
         .interact_text()?;
 
+    config.enrollment.min_face_size_ratio = Input::with_theme(&theme)
+        .with_prompt("Minimum enrollment face size ratio (0.10 - 0.75; lower allows more distance)")
+        .default(config.enrollment.min_face_size_ratio)
+        .interact_text()?;
+
     config.liveness.enabled = Confirm::with_theme(&theme)
         .with_prompt("Enable liveness anti-spoofing")
         .default(config.liveness.enabled)
@@ -1370,6 +1375,11 @@ async fn main() -> anyhow::Result<()> {
                     "{} {}",
                     style("enrollment.max_templates:").bold(),
                     config.enrollment.max_templates
+                );
+                println!(
+                    "{} {:.2}",
+                    style("enrollment.min_face_size_ratio:").bold(),
+                    config.enrollment.min_face_size_ratio
                 );
                 println!(
                     "{} {}",

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -7,7 +7,8 @@ use console::{Term, style};
 use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
 use futures::StreamExt;
 use gaze_core::config::{
-    Config, HYBRID_POLICY_OPTIONS, MODEL_QUALITY_OPTIONS, SECURITY_LEVEL_OPTIONS, SecurityLevel,
+    Config, HYBRID_POLICY_OPTIONS, MAX_ENROLLMENT_FACE_SIZE_RATIO, MIN_ENROLLMENT_FACE_SIZE_RATIO,
+    MODEL_QUALITY_OPTIONS, SECURITY_LEVEL_OPTIONS, SecurityLevel,
 };
 use gaze_core::dbus::{
     CaptureStatus, EnrollPrompt, GazeProxy, VerifyResult, apply_config_to_daemon, connect_gaze,
@@ -349,10 +350,18 @@ async fn run_config_wizard(
         .default(config.enrollment.max_templates)
         .interact_text()?;
 
-    config.enrollment.min_face_size_ratio = Input::with_theme(&theme)
+    let min_face_size_ratio: f64 = Input::with_theme(&theme)
         .with_prompt("Minimum enrollment face size ratio (0.10 - 0.75; lower allows more distance)")
         .default(config.enrollment.min_face_size_ratio)
         .interact_text()?;
+    config.enrollment.min_face_size_ratio = if min_face_size_ratio.is_finite() {
+        min_face_size_ratio.clamp(
+            MIN_ENROLLMENT_FACE_SIZE_RATIO,
+            MAX_ENROLLMENT_FACE_SIZE_RATIO,
+        )
+    } else {
+        config.enrollment.effective_min_face_size_ratio() as f64
+    };
 
     config.liveness.enabled = Confirm::with_theme(&theme)
         .with_prompt("Enable liveness anti-spoofing")

--- a/gaze-core/src/config.rs
+++ b/gaze-core/src/config.rs
@@ -12,6 +12,9 @@ pub const DEFAULT_RGB_CAMERA: &str = "primary";
 pub const SECURITY_LEVEL_OPTIONS: [&str; 5] = ["low", "medium", "high", "maximum", "custom"];
 pub const MODEL_QUALITY_OPTIONS: [&str; 2] = ["standard", "accurate"];
 pub const HYBRID_POLICY_OPTIONS: [&str; 4] = ["default", "or", "fallback_on_dark", "and"];
+pub const DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO: f64 = 0.25;
+pub const MIN_ENROLLMENT_FACE_SIZE_RATIO: f64 = 0.10;
+pub const MAX_ENROLLMENT_FACE_SIZE_RATIO: f64 = 0.75;
 
 fn default_level() -> String {
     "medium".to_string()
@@ -340,16 +343,48 @@ fn default_true() -> bool {
 pub struct EnrollmentConfig {
     #[serde(default = "default_max_templates")]
     pub max_templates: u32,
+    #[serde(default = "default_enrollment_min_face_size_ratio")]
+    pub min_face_size_ratio: f64,
 }
 
 fn default_max_templates() -> u32 {
     2
 }
 
+fn default_enrollment_min_face_size_ratio() -> f64 {
+    DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO
+}
+
+impl EnrollmentConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if !self.min_face_size_ratio.is_finite()
+            || !(MIN_ENROLLMENT_FACE_SIZE_RATIO..=MAX_ENROLLMENT_FACE_SIZE_RATIO)
+                .contains(&self.min_face_size_ratio)
+        {
+            anyhow::bail!(
+                "enrollment.min_face_size_ratio must be between {} and {}, got {}",
+                MIN_ENROLLMENT_FACE_SIZE_RATIO,
+                MAX_ENROLLMENT_FACE_SIZE_RATIO,
+                self.min_face_size_ratio
+            );
+        }
+        Ok(())
+    }
+
+    pub fn effective_min_face_size_ratio(&self) -> f32 {
+        if self.validate().is_ok() {
+            self.min_face_size_ratio as f32
+        } else {
+            DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO as f32
+        }
+    }
+}
+
 impl Default for EnrollmentConfig {
     fn default() -> Self {
         Self {
             max_templates: default_max_templates(),
+            min_face_size_ratio: default_enrollment_min_face_size_ratio(),
         }
     }
 }
@@ -389,6 +424,9 @@ impl Config {
             // fall back. Rejection is enforced at the set_config (admin input) boundary.
             if let Err(e) = config.security.validate() {
                 tracing::warn!("{e}; using safe fallbacks for invalid security fields");
+            }
+            if let Err(e) = config.enrollment.validate() {
+                tracing::warn!("{e}; using the default enrollment face-size ratio");
             }
             Ok(config)
         } else {
@@ -567,6 +605,10 @@ mod tests {
         assert!(config.auth.abort_if_ssh);
         assert!(config.auth.abort_if_lid_closed);
         assert_eq!(config.enrollment.max_templates, 2);
+        assert_eq!(
+            config.enrollment.min_face_size_ratio,
+            DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO
+        );
         assert!(!config.storage.encrypt_templates);
     }
 
@@ -588,7 +630,10 @@ mod tests {
                 require_confirmation: true,
                 resume_grace_ms: 3000,
             },
-            enrollment: EnrollmentConfig { max_templates: 8 },
+            enrollment: EnrollmentConfig {
+                max_templates: 8,
+                min_face_size_ratio: 0.20,
+            },
             liveness: LivenessConfig {
                 enabled: true,
                 threshold: 0.9,
@@ -618,6 +663,7 @@ mod tests {
         assert!(!loaded.auth.abort_if_lid_closed);
         assert!(loaded.auth.require_confirmation);
         assert_eq!(loaded.enrollment.max_templates, 8);
+        assert_eq!(loaded.enrollment.min_face_size_ratio, 0.20);
         assert!(loaded.liveness.enabled);
         assert_eq!(loaded.liveness.threshold, 0.9);
         assert_eq!(loaded.liveness.max_frames, 25);
@@ -673,7 +719,34 @@ mod tests {
         assert!(config.auth.abort_if_lid_closed);
         assert!(!config.auth.require_confirmation);
         assert_eq!(config.enrollment.max_templates, 2);
+        assert_eq!(
+            config.enrollment.min_face_size_ratio,
+            DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO
+        );
         assert!(!config.storage.encrypt_templates);
+    }
+
+    #[test]
+    fn enrollment_face_size_ratio_validates_and_falls_back_safely() {
+        let mut enrollment = EnrollmentConfig::default();
+        assert!(enrollment.validate().is_ok());
+        assert_eq!(
+            enrollment.effective_min_face_size_ratio(),
+            DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO as f32
+        );
+
+        enrollment.min_face_size_ratio = 0.20;
+        assert!(enrollment.validate().is_ok());
+        assert_eq!(enrollment.effective_min_face_size_ratio(), 0.20);
+
+        for invalid in [0.0, 0.09, 0.76, f64::NAN, f64::INFINITY] {
+            enrollment.min_face_size_ratio = invalid;
+            assert!(enrollment.validate().is_err());
+            assert_eq!(
+                enrollment.effective_min_face_size_ratio(),
+                DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO as f32
+            );
+        }
     }
 
     #[test]

--- a/gaze-core/src/face.rs
+++ b/gaze-core/src/face.rs
@@ -5,7 +5,6 @@ use opencv::core::Mat;
 use opencv::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
-const MIN_FACE_SIZE_RATIO: f32 = 0.25;
 const MAX_FACE_SIZE_RATIO: f32 = 0.78;
 const ENROLL_POSE_STABILITY_WINDOW: usize = 2;
 const ENROLL_STABLE_YAW_RANGE: f32 = 0.08;
@@ -52,6 +51,7 @@ fn geometry_status(
     frame_w: f32,
     frame_h: f32,
     check_centering_and_proximity: bool,
+    min_face_size_ratio: f32,
 ) -> Option<CaptureStatus> {
     if bbox_is_clipped(bbox, frame_w, frame_h) {
         return Some(CaptureStatus::Clipped);
@@ -70,7 +70,7 @@ fn geometry_status(
 
     if (norm_cx - 0.5).abs() >= 0.2 || (norm_cy - 0.5).abs() >= 0.2 {
         Some(CaptureStatus::NotCentered)
-    } else if face_size_ratio < MIN_FACE_SIZE_RATIO {
+    } else if face_size_ratio < min_face_size_ratio {
         Some(CaptureStatus::TooFar)
     } else if face_size_ratio > MAX_FACE_SIZE_RATIO {
         Some(CaptureStatus::TooClose)
@@ -238,6 +238,7 @@ pub struct FaceChecker {
     pub rgb_luma_history: std::collections::VecDeque<u8>,
     pub spectrum: Spectrum,
     pub check_centering_and_proximity: bool,
+    pub min_face_size_ratio: f32,
 }
 
 impl FaceChecker {
@@ -253,6 +254,7 @@ impl FaceChecker {
             rgb_luma_history: std::collections::VecDeque::new(),
             spectrum,
             check_centering_and_proximity,
+            min_face_size_ratio: config.enrollment.effective_min_face_size_ratio(),
         }
     }
 
@@ -306,6 +308,7 @@ impl FaceChecker {
             frame.cols() as f32,
             frame.rows() as f32,
             self.check_centering_and_proximity,
+            self.min_face_size_ratio,
         ) {
             status
         } else if kps.is_none() {
@@ -506,31 +509,35 @@ mod tests {
     #[test]
     fn geometry_uses_square_detector_axes_for_centering() {
         assert_eq!(
-            geometry_status((240.0, 240.0, 400.0, 400.0), 640.0, 480.0, true),
+            geometry_status((240.0, 240.0, 400.0, 400.0), 640.0, 480.0, true, 0.25),
             None
         );
         assert_eq!(
-            geometry_status((240.0, 240.0, 400.0, 400.0), 480.0, 640.0, true),
+            geometry_status((240.0, 240.0, 400.0, 400.0), 480.0, 640.0, true, 0.25),
             None
         );
         assert_eq!(
-            geometry_status((400.0, 240.0, 560.0, 400.0), 640.0, 480.0, true),
+            geometry_status((400.0, 240.0, 560.0, 400.0), 640.0, 480.0, true, 0.25),
             Some(CaptureStatus::NotCentered)
         );
     }
 
     #[test]
-    fn geometry_keeps_the_lower_face_size_threshold() {
+    fn geometry_uses_the_configured_lower_face_size_threshold() {
         assert_eq!(
-            geometry_status((375.0, 375.0, 625.0, 625.0), 1000.0, 1000.0, true),
+            geometry_status((375.0, 375.0, 625.0, 625.0), 1000.0, 1000.0, true, 0.25),
             None
         );
         assert_eq!(
-            geometry_status((380.0, 380.0, 620.0, 620.0), 1000.0, 1000.0, true),
+            geometry_status((380.0, 380.0, 620.0, 620.0), 1000.0, 1000.0, true, 0.25),
             Some(CaptureStatus::TooFar)
         );
         assert_eq!(
-            geometry_status((105.0, 105.0, 895.0, 895.0), 1000.0, 1000.0, true),
+            geometry_status((380.0, 380.0, 620.0, 620.0), 1000.0, 1000.0, true, 0.20),
+            None
+        );
+        assert_eq!(
+            geometry_status((105.0, 105.0, 895.0, 895.0), 1000.0, 1000.0, true, 0.25),
             Some(CaptureStatus::TooClose)
         );
     }
@@ -538,11 +545,11 @@ mod tests {
     #[test]
     fn authentication_skips_centering_and_proximity_but_still_rejects_clipping() {
         assert_eq!(
-            geometry_status((400.0, 240.0, 560.0, 400.0), 640.0, 480.0, false),
+            geometry_status((400.0, 240.0, 560.0, 400.0), 640.0, 480.0, false, 0.25),
             None
         );
         assert_eq!(
-            geometry_status((300.0, 85.0, 380.0, 200.0), 640.0, 480.0, false),
+            geometry_status((300.0, 85.0, 380.0, 200.0), 640.0, 480.0, false, 0.25),
             Some(CaptureStatus::Clipped)
         );
     }

--- a/gaze-gui/src/window.rs
+++ b/gaze-gui/src/window.rs
@@ -1,5 +1,8 @@
 use crate::capture_dialog;
-use gaze_core::config::{Config, DEFAULT_RGB_CAMERA, SecurityLevel};
+use gaze_core::config::{
+    Config, DEFAULT_RGB_CAMERA, MAX_ENROLLMENT_FACE_SIZE_RATIO, MIN_ENROLLMENT_FACE_SIZE_RATIO,
+    SecurityLevel,
+};
 use gaze_core::dbus::{
     GazeProxy, apply_config_to_daemon, connect_gaze, dbus_error_message, dbus_is_file_not_found,
     dbus_is_not_activatable, load_config_from_daemon,
@@ -97,6 +100,7 @@ struct ConfigRows<'a> {
     emitter: &'a gtk4::Switch,
     dark_luma_threshold: &'a libadwaita::SpinRow,
     templates: &'a libadwaita::SpinRow,
+    min_face_size_ratio: &'a libadwaita::SpinRow,
     liveness_enabled: &'a gtk4::Switch,
     liveness_threshold: &'a libadwaita::SpinRow,
     liveness_max_frames: &'a libadwaita::SpinRow,
@@ -150,6 +154,8 @@ fn populate_config_rows(cfg: &Config, rows: ConfigRows<'_>, choices: CameraChoic
         .set_value(cfg.cameras.dark_luma_threshold as f64);
     rows.templates
         .set_value(cfg.enrollment.max_templates as f64);
+    rows.min_face_size_ratio
+        .set_value(cfg.enrollment.min_face_size_ratio);
     rows.liveness_enabled.set_active(cfg.liveness.enabled);
     rows.liveness_threshold.set_value(cfg.liveness.threshold);
     rows.liveness_max_frames
@@ -287,6 +293,17 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
     templates_row.set_subtitle("Number of capture sets stored per face");
     enrollment_group.add(&templates_row);
 
+    let min_face_size_ratio_row = libadwaita::SpinRow::with_range(
+        MIN_ENROLLMENT_FACE_SIZE_RATIO,
+        MAX_ENROLLMENT_FACE_SIZE_RATIO,
+        0.01,
+    );
+    min_face_size_ratio_row.set_digits(2);
+    min_face_size_ratio_row.set_title("Minimum Face Size Ratio");
+    min_face_size_ratio_row
+        .set_subtitle("Smallest accepted face during enrollment; lower allows more distance");
+    enrollment_group.add(&min_face_size_ratio_row);
+
     let liveness_group = libadwaita::PreferencesGroup::new();
     liveness_group.set_title("Liveness Anti-Spoofing");
     page.add(&liveness_group);
@@ -420,6 +437,8 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         #[weak]
         templates_row,
         #[weak]
+        min_face_size_ratio_row,
+        #[weak]
         liveness_enabled_switch,
         #[weak]
         liveness_threshold_row,
@@ -479,6 +498,7 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
             cfg.cameras.emitter_enabled = emitter_switch.is_active();
             cfg.cameras.dark_luma_threshold = dark_luma_threshold_row.value() as u8;
             cfg.enrollment.max_templates = templates_row.value() as u32;
+            cfg.enrollment.min_face_size_ratio = min_face_size_ratio_row.value();
             cfg.liveness.enabled = liveness_enabled_switch.is_active();
             cfg.liveness.threshold = liveness_threshold_row.value();
             cfg.liveness.max_frames = liveness_max_frames_row.value() as u32;
@@ -530,6 +550,11 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         move |_| apply_changes()
     ));
     templates_row.connect_value_notify(glib::clone!(
+        #[strong]
+        apply_changes,
+        move |_| apply_changes()
+    ));
+    min_face_size_ratio_row.connect_value_notify(glib::clone!(
         #[strong]
         apply_changes,
         move |_| apply_changes()
@@ -621,6 +646,7 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
                 emitter: &emitter_switch,
                 dark_luma_threshold: &dark_luma_threshold_row,
                 templates: &templates_row,
+                min_face_size_ratio: &min_face_size_ratio_row,
                 liveness_enabled: &liveness_enabled_switch,
                 liveness_threshold: &liveness_threshold_row,
                 liveness_max_frames: &liveness_max_frames_row,
@@ -769,6 +795,8 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         #[weak]
         templates_row,
         #[weak]
+        min_face_size_ratio_row,
+        #[weak]
         liveness_enabled_switch,
         #[weak]
         liveness_threshold_row,
@@ -815,6 +843,7 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
                         emitter: &emitter_switch,
                         dark_luma_threshold: &dark_luma_threshold_row,
                         templates: &templates_row,
+                        min_face_size_ratio: &min_face_size_ratio_row,
                         liveness_enabled: &liveness_enabled_switch,
                         liveness_threshold: &liveness_threshold_row,
                         liveness_max_frames: &liveness_max_frames_row,

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -2612,6 +2612,10 @@ impl AuthDaemon {
             .security
             .validate()
             .map_err(|e| fdo::Error::InvalidArgs(e.to_string()))?;
+        new_config
+            .enrollment
+            .validate()
+            .map_err(|e| fdo::Error::InvalidArgs(e.to_string()))?;
 
         self.cancel_active_tasks();
 

--- a/packaging/config/config.toml
+++ b/packaging/config/config.toml
@@ -41,6 +41,9 @@ resume_grace_ms = 0
 
 [enrollment]
 max_templates = 2
+# Smallest accepted face bbox as a fraction of the frame's shorter side.
+# Lower values allow enrollment from farther away; valid range: 0.10-0.75.
+min_face_size_ratio = 0.25
 
 # Liveness anti-spoofing runs a local MiniFASNet-V2 PAD model on the detected face crop.
 # The model is downloaded into /var/cache/gaze on first use if missing.


### PR DESCRIPTION
Fixes #273

Adds `enrollment.min_face_size_ratio`, which controls the smallest face accepted during enrollment as a fraction of the frame’s shorter side.

- Preserves the current `0.25` default.
- Validates values from `0.10` through `0.75`.
- Falls back safely to the default for an invalid on-disk value.
- Rejects invalid values submitted through D-Bus.
- Adds CLI and GUI controls, `gaze doctor` validation, packaged config, documentation, and tests.

This affects enrollment only. Authentication retains its existing centering and proximity behavior.

Validation run:

- `cargo fmt --all -- --check`
- `gaze-core`: 62 tests passed
- `gaze-cli`: 20 tests passed
- `cargo check -p gaze-gui -p gaze`