### PR TITLE
fix(camera): PipeWire aspect ratio enrollment failure

### DIFF
--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -496,7 +496,7 @@ async fn handle_enroll(
                         current_enroll_msg = raw_msg.to_string();
                         current_time_remaining = (time_remaining > 0.0).then_some(time_remaining);
 
-                        if matches!(raw_msg, EnrollPrompt::DbFailed | EnrollPrompt::Cancelled) {
+                        if matches!(raw_msg, EnrollPrompt::DbFailed | EnrollPrompt::CameraFailed | EnrollPrompt::Cancelled) {
                             is_failed = true;
                             break;
                         }
@@ -553,7 +553,11 @@ async fn handle_enroll(
             style(face).green()
         ))?;
     } else if is_failed {
-        term.write_line(&format!("{} Enrollment failed", style("✗").red().bold()))?;
+        term.write_line(&format!(
+            "{} Enrollment failed: {}",
+            style("✗").red().bold(),
+            current_enroll_msg
+        ))?;
     }
     Ok(())
 }

--- a/gaze-core/src/camera.rs
+++ b/gaze-core/src/camera.rs
@@ -1,7 +1,7 @@
 use gstreamer::prelude::*;
 use opencv::core::Mat;
 use opencv::prelude::*;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::{CameraConfig, DEFAULT_RGB_CAMERA};
 
@@ -176,7 +176,7 @@ impl Camera {
         };
 
         let pipeline_str = format!(
-            "{src_element} ! video/x-raw; image/jpeg ! decodebin ! videoconvert ! videoscale ! appsink name=gaze_sink"
+            "{src_element} ! video/x-raw,pixel-aspect-ratio=1/1; image/jpeg ! decodebin ! videoconvert ! videoscale ! appsink name=gaze_sink"
         );
         info!("Attempting to open GStreamer camera: {}", pipeline_str);
 
@@ -259,8 +259,9 @@ impl Iterator for Camera {
                 .appsink
                 .try_pull_sample(gstreamer::ClockTime::from_seconds(5))
             {
-                if let Ok(mat) = self.sample_to_mat(&sample) {
-                    return Some(mat);
+                match self.sample_to_mat(&sample) {
+                    Ok(mat) => return Some(mat),
+                    Err(err) => warn!("Dropping camera frame: {err:#}"),
                 }
             } else {
                 if self.appsink.is_eos() {
@@ -275,7 +276,20 @@ impl Iterator for Camera {
                 }) {
                     match msg.view() {
                         gstreamer::MessageView::Error(err) => {
-                            info!("Camera pipeline error: {}", err.error());
+                            if let Some(src) = err.src() {
+                                warn!(
+                                    source = %src.path_string(),
+                                    debug = ?err.debug(),
+                                    "Camera pipeline error: {}",
+                                    err.error()
+                                );
+                            } else {
+                                warn!(
+                                    debug = ?err.debug(),
+                                    "Camera pipeline error: {}",
+                                    err.error()
+                                );
+                            }
                         }
                         _ => info!("Camera stream ended (EOS)"),
                     }

--- a/gaze-core/src/dbus.rs
+++ b/gaze-core/src/dbus.rs
@@ -86,6 +86,8 @@ pub enum EnrollPrompt {
     LookRight,
     #[strum(serialize = "Database error during enrollment")]
     DbFailed,
+    #[strum(serialize = "Camera error during enrollment")]
+    CameraFailed,
     #[strum(serialize = "Enrollment cancelled")]
     Cancelled,
     #[strum(serialize = "Captured")]

--- a/gaze-gui/src/capture_dialog.rs
+++ b/gaze-gui/src/capture_dialog.rs
@@ -339,7 +339,7 @@ pub fn show_capture_dialog(
                                         progress_label.set_text(&format!("{}/{}", prog, max));
                                     }
 
-                                    if matches!(raw_msg, EnrollPrompt::DbFailed | EnrollPrompt::Cancelled) {
+                                    if matches!(raw_msg, EnrollPrompt::DbFailed | EnrollPrompt::CameraFailed | EnrollPrompt::Cancelled) {
                                         prompt_label.set_text(raw_msg.as_ref());
                                         stop_btn.set_visible(false);
                                         break;

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -2512,7 +2512,7 @@ impl AuthDaemon {
                             }
                             EnrollMsg::Error(e) => {
                                 error!("Enrollment error: {e}");
-                                let _ = Self::enroll_status(&ctxt, &face_name, max_steps, max_steps, true, EnrollPrompt::DbFailed, -1.0).await;
+                                let _ = Self::enroll_status(&ctxt, &face_name, max_steps, max_steps, true, EnrollPrompt::CameraFailed, -1.0).await;
                                 stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
                                 return;
                             }


### PR DESCRIPTION
Fixes enrollment failure when PipeWire advertises an invalid pixel-aspect-ratio that causes GStreamer videoscale negotiation to overflow.

  The camera pipeline now normalizes raw input PAR before scaling, preserves JPEG fallback, logs frame conversion/pipeline errors, and reports camera
  enrollment failures distinctly from database failures.

  Validation:
  - cargo fmt --check
  - cargo check --workspace
  - cargo test --workspace