### PR TITLE
fix(camera): make stalled frame reads cancellable

### DIFF
--- a/gaze-core/src/camera.rs
+++ b/gaze-core/src/camera.rs
@@ -1,6 +1,7 @@
 use gstreamer::prelude::*;
 use opencv::core::Mat;
 use opencv::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{info, warn};
 
 use crate::config::{CameraConfig, DEFAULT_RGB_CAMERA};
@@ -118,6 +119,13 @@ pub fn resolve_node(source: &str) -> Option<String> {
 
 const PRIMARY_CAMERA_DISPLAY_NAME: &str = "Primary Camera";
 const DEVICE_SETTLE_TIMEOUT_MS: u64 = 100;
+const INTERRUPTIBLE_POLL_TIMEOUT_MS: u64 = 100;
+
+enum FramePoll {
+    Frame(Mat),
+    Timeout,
+    Ended,
+}
 
 pub struct Camera {
     pipeline: gstreamer::Pipeline,
@@ -126,10 +134,27 @@ pub struct Camera {
 
 impl Drop for Camera {
     fn drop(&mut self) {
-        let _ = self.pipeline.set_state(gstreamer::State::Null);
-        let _ = self
+        if let Err(err) = self.pipeline.set_state(gstreamer::State::Null) {
+            warn!("Failed to stop camera pipeline: {err}");
+            return;
+        }
+
+        let (result, current, pending) = self
             .pipeline
             .state(Some(gstreamer::ClockTime::from_seconds(2)));
+        if let Err(err) = result {
+            warn!(
+                ?current,
+                ?pending,
+                "Camera pipeline did not stop cleanly: {err}"
+            );
+        } else if current != gstreamer::State::Null {
+            warn!(
+                ?current,
+                ?pending,
+                "Camera pipeline did not reach the Null state"
+            );
+        }
     }
 }
 
@@ -248,6 +273,72 @@ impl Camera {
         opencv::core::flip(&frame, &mut mirrored, 1)?;
         Ok(mirrored)
     }
+
+    fn poll_frame(&self, timeout: gstreamer::ClockTime) -> FramePoll {
+        if let Some(sample) = self.appsink.try_pull_sample(timeout) {
+            return match self.sample_to_mat(&sample) {
+                Ok(mat) => FramePoll::Frame(mat),
+                Err(err) => {
+                    warn!("Dropping camera frame: {err:#}");
+                    FramePoll::Timeout
+                }
+            };
+        }
+
+        if self.appsink.is_eos() {
+            info!("Camera stream ended (EOS)");
+            return FramePoll::Ended;
+        }
+        if let Some(msg) = self.pipeline.bus().and_then(|bus| {
+            bus.timed_pop_filtered(
+                gstreamer::ClockTime::ZERO,
+                &[gstreamer::MessageType::Error, gstreamer::MessageType::Eos],
+            )
+        }) {
+            match msg.view() {
+                gstreamer::MessageView::Error(err) => {
+                    if let Some(src) = err.src() {
+                        warn!(
+                            source = %src.path_string(),
+                            debug = ?err.debug(),
+                            "Camera pipeline error: {}",
+                            err.error()
+                        );
+                    } else {
+                        warn!(
+                            debug = ?err.debug(),
+                            "Camera pipeline error: {}",
+                            err.error()
+                        );
+                    }
+                }
+                _ => info!("Camera stream ended (EOS)"),
+            }
+            return FramePoll::Ended;
+        }
+        let (_, current_state, _) = self.pipeline.state(Some(gstreamer::ClockTime::ZERO));
+        if current_state != gstreamer::State::Playing && current_state != gstreamer::State::Paused {
+            info!("Camera pipeline stopped: {:?}", current_state);
+            return FramePoll::Ended;
+        }
+
+        FramePoll::Timeout
+    }
+
+    /// Wait for the next frame while checking `stop` between short polling intervals.
+    pub fn next_interruptible(&mut self, stop: &AtomicBool) -> Option<Mat> {
+        while !stop.load(Ordering::Acquire) {
+            match self.poll_frame(gstreamer::ClockTime::from_mseconds(
+                INTERRUPTIBLE_POLL_TIMEOUT_MS,
+            )) {
+                FramePoll::Frame(frame) => return Some(frame),
+                FramePoll::Timeout => {}
+                FramePoll::Ended => return None,
+            }
+        }
+
+        None
+    }
 }
 
 impl Iterator for Camera {
@@ -255,53 +346,10 @@ impl Iterator for Camera {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(sample) = self
-                .appsink
-                .try_pull_sample(gstreamer::ClockTime::from_seconds(5))
-            {
-                match self.sample_to_mat(&sample) {
-                    Ok(mat) => return Some(mat),
-                    Err(err) => warn!("Dropping camera frame: {err:#}"),
-                }
-            } else {
-                if self.appsink.is_eos() {
-                    info!("Camera stream ended (EOS)");
-                    return None;
-                }
-                if let Some(msg) = self.pipeline.bus().and_then(|bus| {
-                    bus.timed_pop_filtered(
-                        gstreamer::ClockTime::ZERO,
-                        &[gstreamer::MessageType::Error, gstreamer::MessageType::Eos],
-                    )
-                }) {
-                    match msg.view() {
-                        gstreamer::MessageView::Error(err) => {
-                            if let Some(src) = err.src() {
-                                warn!(
-                                    source = %src.path_string(),
-                                    debug = ?err.debug(),
-                                    "Camera pipeline error: {}",
-                                    err.error()
-                                );
-                            } else {
-                                warn!(
-                                    debug = ?err.debug(),
-                                    "Camera pipeline error: {}",
-                                    err.error()
-                                );
-                            }
-                        }
-                        _ => info!("Camera stream ended (EOS)"),
-                    }
-                    return None;
-                }
-                let (_, current_state, _) = self.pipeline.state(Some(gstreamer::ClockTime::ZERO));
-                if current_state != gstreamer::State::Playing
-                    && current_state != gstreamer::State::Paused
-                {
-                    info!("Camera pipeline stopped: {:?}", current_state);
-                    return None;
-                }
+            match self.poll_frame(gstreamer::ClockTime::from_seconds(5)) {
+                FramePoll::Frame(frame) => return Some(frame),
+                FramePoll::Timeout => {}
+                FramePoll::Ended => return None,
             }
         }
     }
@@ -506,6 +554,34 @@ mod tests {
             frames += 1;
             assert!(frames < 10, "iterator must end after the pipeline errors");
         }
+    }
+
+    #[test]
+    fn interruptible_read_stops_when_live_pipeline_has_no_frames() {
+        let stop = std::sync::Arc::new(AtomicBool::new(false));
+        let worker_stop = stop.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+
+        let worker = std::thread::spawn(move || {
+            let mut camera = Camera::open("appsrc is-live=true format=time")
+                .expect("live pipeline without frames");
+            ready_tx.send(()).expect("signal camera readiness");
+            let stopped = camera.next_interruptible(&worker_stop).is_none();
+            done_tx.send(stopped).expect("signal camera shutdown");
+        });
+
+        ready_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("camera must become ready");
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        stop.store(true, Ordering::Release);
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("camera read must observe cancellation")
+        );
+        worker.join().expect("camera worker must exit");
     }
 
     #[test]

--- a/gaze-core/src/camera.rs
+++ b/gaze-core/src/camera.rs
@@ -327,7 +327,7 @@ impl Camera {
 
     /// Wait for the next frame while checking `stop` between short polling intervals.
     pub fn next_interruptible(&mut self, stop: &AtomicBool) -> Option<Mat> {
-        while !stop.load(Ordering::Acquire) {
+        while !stop.load(Ordering::Relaxed) {
             match self.poll_frame(gstreamer::ClockTime::from_mseconds(
                 INTERRUPTIBLE_POLL_TIMEOUT_MS,
             )) {

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -483,10 +483,9 @@ impl AuthDaemon {
         )
     }
 
-    fn cancel_active_tasks(&self) {
-        if let Ok(mut cancel) = self.active_cancel.try_lock()
-            && let Some(sender) = cancel.take()
-        {
+    async fn cancel_active_tasks(&self) {
+        let mut cancel = self.active_cancel.lock().await;
+        if let Some(sender) = cancel.take() {
             let _ = sender.send(());
         }
     }
@@ -1329,7 +1328,7 @@ impl AuthDaemon {
                 return Ok(());
             }
             if caller_uid == 0 {
-                self.cancel_active_tasks();
+                self.cancel_active_tasks().await;
                 info!(
                     sender = %sender,
                     previous_sender = %existing.sender,
@@ -1427,7 +1426,7 @@ impl AuthDaemon {
                 return Err(fdo::Error::Failed("Sender does not own the claim".into()));
             }
 
-            self.cancel_active_tasks();
+            self.cancel_active_tasks().await;
             *state = None;
             info!(sender = %sender, "Released daemon");
             Ok(())
@@ -1462,7 +1461,7 @@ impl AuthDaemon {
 
         let username = claim.username.clone();
         let signal_destination = Self::signal_destination(&claim.sender)?;
-        self.cancel_active_tasks();
+        self.cancel_active_tasks().await;
 
         let (tx, mut rx) = oneshot::channel();
         *self.active_cancel.lock().await = Some(tx);
@@ -1581,7 +1580,7 @@ impl AuthDaemon {
                     let mut live_scores: Vec<f32> = Vec::new();
                     let mut landmark_seq: Vec<[(f32, f32); 5]> = Vec::new();
 
-                    for frame in &mut cam {
+                    while let Some(frame) = cam.next_interruptible(&stop_clone) {
                         if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                             break;
                         }
@@ -1729,7 +1728,7 @@ impl AuthDaemon {
                     let mut dark_gate = IrDarkFrameGate::new(config_clone.cameras.dark_luma_threshold);
                     let mut landmark_seq: Vec<[(f32, f32); 5]> = Vec::new();
 
-                    for frame in &mut cam {
+                    while let Some(frame) = cam.next_interruptible(&stop_clone) {
                         if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                             break;
                         }
@@ -1959,7 +1958,7 @@ impl AuthDaemon {
 
     async fn verify_stop(&self, #[zbus(header)] header: Header<'_>) -> fdo::Result<()> {
         self.check_claim(&header).await?;
-        self.cancel_active_tasks();
+        self.cancel_active_tasks().await;
         Ok(())
     }
 
@@ -1972,7 +1971,7 @@ impl AuthDaemon {
         let claim = self.check_claim(&header).await?;
         let username = claim.username.clone();
         let signal_destination = Self::signal_destination(&claim.sender)?;
-        self.cancel_active_tasks();
+        self.cancel_active_tasks().await;
 
         UserDatabase::validate_face_name(&face_name).map_err(Self::map_user_db_error)?;
 
@@ -2083,7 +2082,7 @@ impl AuthDaemon {
                             };
                             let mut pose_stability = EnrollmentPoseStability::default();
 
-                            for frame in &mut cam {
+                            while let Some(frame) = cam.next_interruptible(&stop_clone) {
                                 if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                                     return;
                                 }
@@ -2153,7 +2152,7 @@ impl AuthDaemon {
                     let mut captured_for_step = false;
                     let mut pose_stability = EnrollmentPoseStability::default();
 
-                    for frame in &mut cam {
+                    while let Some(frame) = cam.next_interruptible(&stop_clone) {
                         if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                             break;
                         }
@@ -2271,7 +2270,7 @@ impl AuthDaemon {
                                 }
                             };
 
-                            for frame in &mut cam {
+                            while let Some(frame) = cam.next_interruptible(&stop_clone) {
                                 if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                                     return;
                                 }
@@ -2339,7 +2338,7 @@ impl AuthDaemon {
                     let mut pose_stability = EnrollmentPoseStability::default();
                     let mut pose_baseline = None;
 
-                    for frame in &mut cam {
+                    while let Some(frame) = cam.next_interruptible(&stop_clone) {
                         if stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
                             break;
                         }
@@ -2547,7 +2546,7 @@ impl AuthDaemon {
 
     async fn enroll_stop(&self, #[zbus(header)] header: Header<'_>) -> fdo::Result<()> {
         self.check_claim(&header).await?;
-        self.cancel_active_tasks();
+        self.cancel_active_tasks().await;
         Ok(())
     }
 
@@ -2660,7 +2659,7 @@ impl AuthDaemon {
             .validate()
             .map_err(|e| fdo::Error::InvalidArgs(e.to_string()))?;
 
-        self.cancel_active_tasks();
+        self.cancel_active_tasks().await;
 
         let new_liveness_detector = if new_config.liveness.enabled {
             let path = crate::models::ensure_liveness_model(gaze_core::config::MODELS_DIR)


### PR DESCRIPTION
Closes #298

## Summary

- Add an interruptible camera read that polls AppSink every 100 milliseconds.
- Use the interruptible read in all RGB and infrared verification and enrollment
  workers.
- Wait for the active cancellation lock instead of using `try_lock()`.
- Report GStreamer pipeline shutdown failures.
- Add a regression test for cancelling a live pipeline that produces no frames.

## Why

The existing `Camera::next()` retries its five-second AppSink wait internally.
When a pipeline remains Playing or Paused without delivering frames, the method
never returns to the daemon worker. The worker therefore cannot check
`stop_flag`.

This can leave the PipeWire camera stream active after the D-Bus client has
released its claim. The camera LED then remains on indefinitely.

The new interruptible read returns to its cancellation check at most every
100 milliseconds. Cancellation lets the worker exit and drop `Camera`, which
changes the GStreamer pipeline to `Null`.

`cancel_active_tasks()` now waits for its mutex. The previous `try_lock()` could
silently skip cancellation during lock contention.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --release --locked --offline -- -D warnings`
- `cargo test --workspace --release --locked --offline`
  - 170 passed
  - 2 TPM hardware tests ignored
  - 0 failed
- `cargo audit`
  - 463 locked dependencies scanned
  - no vulnerabilities reported
- New no-frame cancellation regression test passes.

## Manual verification

Verified on Gentoo Linux with PipeWire 1.6.8 and a Syntek `174f:11b3`
integrated RGB/IR camera.

### Stalled no-frame pipeline

The patched daemon ran on the system D-Bus with a temporary live `appsrc`
pipeline that produced no frames.

A stack snapshot confirmed the camera worker was waiting inside
`gst_app_sink_try_pull_sample`. After terminating the D-Bus client:

- Gaze logged `VerifyStart: cancelled`.
- No worker remained inside `gst_app_sink_try_pull_sample` after 300 milliseconds.
- The patched daemon remained healthy.

### Physical camera

The patched daemon then ran with the original RGB and infrared configuration.

- Both RGB and infrared pipelines opened successfully.
- PipeWire showed an active `gazed` video stream before cancellation.
- Terminating the D-Bus client produced `VerifyStart: cancelled`.
- PipeWire removed the active `gazed` stream after cancellation.
- The patched daemon remained healthy.

The original `/etc/gaze/config.toml` was restored byte-for-byte and the packaged
`gazed.service` was restarted afterward.
