### PR TITLE
fix(pam): show dark hint instead of camera prompt

### DIFF
--- a/pam-gaze-core/src/lib.rs
+++ b/pam-gaze-core/src/lib.rs
@@ -475,6 +475,12 @@ fn auth_outcome(
 }
 
 pub async fn authenticate_biometric(username: &str) -> anyhow::Result<AuthOutcome> {
+    Ok(authenticate_biometric_with_status(username).await?.0)
+}
+
+pub async fn authenticate_biometric_with_status(
+    username: &str,
+) -> anyhow::Result<(AuthOutcome, Option<gaze_core::dbus::CaptureStatus>)> {
     let (_config, proxy) = setup_auth_env()
         .await
         .map_err(|e| anyhow::anyhow!("PAM error: {}", e))?;
@@ -524,7 +530,7 @@ pub async fn authenticate_biometric(username: &str) -> anyhow::Result<AuthOutcom
 
     guard.active = false;
     let _ = proxy.release().await;
-    Ok(outcome)
+    Ok((outcome, last_status))
 }
 
 pub fn get_user_uid(username: &str) -> Option<u32> {

--- a/pam-gaze/src/lib.rs
+++ b/pam-gaze/src/lib.rs
@@ -60,13 +60,18 @@ unsafe fn do_authenticate(pamh: PamHandle) -> c_int {
 
         match timeout(
             Duration::from_secs(CAMERA_AUTH_TIMEOUT_SECS),
-            authenticate_biometric(&username),
+            authenticate_biometric_with_status(&username),
         )
         .await
         {
-            Ok(Ok(AuthOutcome::Match)) => Ok(()),
-            Ok(Ok(AuthOutcome::NoMatch)) => Err(PAM_AUTH_ERR),
-            Ok(Ok(AuthOutcome::Unavailable)) => Err(PAM_AUTHINFO_UNAVAIL),
+            Ok(Ok((AuthOutcome::Match, _))) => Ok(()),
+            Ok(Ok((AuthOutcome::NoMatch, _))) => Err(PAM_AUTH_ERR),
+            Ok(Ok((AuthOutcome::Unavailable, status))) => {
+                if let Some(status) = status {
+                    unsafe { say(pamh, status.as_ref()) };
+                }
+                Err(PAM_AUTHINFO_UNAVAIL)
+            }
             _ => Err(PAM_AUTHINFO_UNAVAIL),
         }
     });


### PR DESCRIPTION
The polkit dialog wrote "Please look at the camera" once up front and never updated it. When the scene is too dark, the daemon aborts and reports `TooDark` to PAM, but the status was only used to pick a return code, so the stale prompt stayed on screen.

- Add `authenticate_biometric_with_status`, returning the final `CaptureStatus`; `authenticate_biometric` becomes a thin wrapper so grosshack is unaffected.
- On an `Unavailable` outcome, rewrite the dialog with the status message before returning, so a dark abort shows "Need more light..." instead of "Please look at the camera".