### PR TITLE
feat(inference): add optional OpenVINO acceleration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,12 @@ build-rust:
     {{ opencv_env }} cargo build -p gaze --release
     {{ opencv_env }} cargo build -p gaze-cli -p gaze-gui -p pam-gaze -p pam-gaze-grosshack --release
 
+# Build all Rust workspace binaries with OpenVINO configuration and runtime support.
+[group("build")]
+build-rust-openvino:
+    {{ opencv_env }} cargo build -p gaze --release --features gaze/openvino
+    {{ opencv_env }} cargo build -p gaze-cli -p gaze-gui -p pam-gaze -p pam-gaze-grosshack --release --features gaze-cli/openvino,gaze-gui/openvino
+
 # Compile the SELinux policy module
 [group("build")]
 build-selinux:
@@ -318,6 +324,12 @@ setup-hooks:
 [group("checks")]
 test:
     {{ opencv_env }} cargo test --workspace --release
+
+# Run inference tests with an OpenVINO-enabled system ONNX Runtime.
+[group("checks")]
+test-openvino:
+    {{ opencv_env }} cargo test -p gaze -p gaze-core --release --features gaze/openvino,gaze-core/openvino
+    {{ opencv_env }} cargo test -p gaze-cli -p gaze-gui --release --features gaze-cli/openvino,gaze-gui/openvino
 
 # Check dependencies for known security advisories
 [group("checks")]

--- a/Justfile
+++ b/Justfile
@@ -324,6 +324,7 @@ setup-hooks:
 [group("checks")]
 test:
     {{ opencv_env }} cargo test --workspace --release
+    {{ opencv_env }} cargo test -p gaze-core --release --no-default-features --features gaze-core/openvino-config config::
 
 # Run inference tests with an OpenVINO-enabled system ONNX Runtime.
 [group("checks")]
@@ -340,6 +341,12 @@ audit:
 [group("checks")]
 lint:
     {{ opencv_env }} cargo clippy --workspace --all-targets -- -D warnings
+
+# Run clippy lints with an OpenVINO-enabled system ONNX Runtime.
+[group("checks")]
+lint-openvino:
+    {{ opencv_env }} cargo clippy -p gaze -p gaze-core --all-targets --features gaze/openvino,gaze-core/openvino -- -D warnings
+    {{ opencv_env }} cargo clippy -p gaze-cli -p gaze-gui --all-targets --features gaze-cli/openvino,gaze-gui/openvino -- -D warnings
 
 # Check formatting (does not write)
 [group("checks")]

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ threshold = 0.8
 OpenVINO selects its device at run time. An OpenVINO-enabled installation
 should use `execution_provider = "openvino"` and `device = "npu"` to select the
 Intel NPU. The same binary can select the Intel GPU by changing `device` to
-`"gpu"`.
+`"gpu"`. The released packages are CPU-only; OpenVINO requires building from
+source with `just build-rust-openvino`.
 
 See the [configuration guide](https://gaze.gundulabs.com/guide/configuration) for all options.
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ enabled = true
 threshold = 0.8
 ```
 
+OpenVINO selects its device at run time. An OpenVINO-enabled installation
+should use `execution_provider = "openvino"` and `device = "npu"` to select the
+Intel NPU. The same binary can select the Intel GPU by changing `device` to
+`"gpu"`.
+
 See the [configuration guide](https://gaze.gundulabs.com/guide/configuration) for all options.
 
 ## CLI usage

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Camera → Face Detection (SCRFD) → Alignment → Embedding (ArcFace) → Matc
 
 ```toml
 # /etc/gaze/config.toml
+[inference]
+execution_provider = "cpu" # cpu | openvino (requires an OpenVINO build)
+device = "cpu"             # cpu | gpu | npu
+
 [security]
 level = "medium"    # low | medium | high | maximum | custom
 
@@ -210,6 +214,9 @@ sudo apt install build-essential pkg-config clang libclang-dev \
 
 # Build
 just build-rust
+
+# Build with OpenVINO support (requires an OpenVINO-enabled system ONNX Runtime)
+just build-rust-openvino
 
 # Package
 just package <deb | rpm | archlinux>

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -70,14 +70,20 @@ execution_provider = "cpu"
 device = "cpu"
 ```
 
-An ONNX Runtime build with the OpenVINO Execution Provider can use an Intel
-GPU or NPU:
+OpenVINO does not select a fixed device at build time. The same
+OpenVINO-enabled Gaze binary can use an Intel CPU, GPU, or NPU. Select the
+device in `/etc/gaze/config.toml`.
+
+An installation with OpenVINO support should select the Intel NPU by default:
 
 ```toml
 [inference]
 execution_provider = "openvino"
-device = "gpu" # or "npu"
+device = "npu"
 ```
+
+Change `device` to `"gpu"` to use the Intel GPU. This does not require
+recompiling Gaze.
 
 The Gaze daemon must also be compiled with the `openvino` Cargo feature.
 CPU-only builds reject `execution_provider = "openvino"` with an error instead

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -15,6 +15,10 @@ dialog, so make sure the `polkit` package is installed.
 ## Default config
 
 ```toml
+[inference]
+execution_provider = "cpu"
+device = "cpu"
+
 [security]
 level = "medium"
 
@@ -53,6 +57,38 @@ packaged default changed, the new template is saved alongside it as
 dpkg keeps your file and asks before replacing it. Any option missing from
 your config uses its built-in default, so you don't need to merge new options
 after upgrading.
+
+## Select the inference device
+
+Gaze always loads its `.onnx` models through ONNX Runtime.
+
+The default uses the ONNX Runtime CPU execution provider:
+
+```toml
+[inference]
+execution_provider = "cpu"
+device = "cpu"
+```
+
+An ONNX Runtime build with the OpenVINO Execution Provider can use an Intel
+GPU or NPU:
+
+```toml
+[inference]
+execution_provider = "openvino"
+device = "gpu" # or "npu"
+```
+
+The Gaze daemon must also be compiled with the `openvino` Cargo feature.
+CPU-only builds reject `execution_provider = "openvino"` with an error instead
+of silently accepting it.
+
+The values stay lowercase in the config. Gaze converts the device name only
+when it calls OpenVINO. ONNX Runtime keeps its CPU execution provider after
+OpenVINO. It runs unsupported model operations on the CPU. If Gaze cannot
+create an OpenVINO session, it logs the error and creates a CPU session.
+`gaze doctor --benchmark` reports the execution provider and device used by
+each loaded model.
 
 ## Change security level
 

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -85,16 +85,18 @@ device = "npu"
 Change `device` to `"gpu"` to use the Intel GPU. This does not require
 recompiling Gaze.
 
-The Gaze daemon must also be compiled with the `openvino` Cargo feature.
-CPU-only builds reject `execution_provider = "openvino"` with an error instead
-of silently accepting it.
+The Gaze daemon must also be compiled with the `openvino` Cargo feature. On a
+CPU-only build, `gaze config` and the GUI refuse to set
+`execution_provider = "openvino"`. A config file that already contains it does
+not stop the daemon: it logs a warning and runs on the CPU, the same way every
+other unusable value in `/etc/gaze/config.toml` is handled.
 
 The values stay lowercase in the config. Gaze converts the device name only
 when it calls OpenVINO. ONNX Runtime keeps its CPU execution provider after
 OpenVINO. It runs unsupported model operations on the CPU. If Gaze cannot
 create an OpenVINO session, it logs the error and creates a CPU session.
-`gaze doctor --benchmark` reports the execution provider and device used by
-each loaded model.
+`gaze doctor --benchmark` reports the execution provider and device each model
+actually uses, and warns when that is not the configured one.
 
 ## Change security level
 

--- a/docs/src/guide/development.md
+++ b/docs/src/guide/development.md
@@ -109,6 +109,13 @@ just build-rust-openvino
 The `openvino` Cargo feature is explicit. The build fails when that feature is
 enabled without a matching ONNX Runtime library.
 
+The OpenVINO-enabled binary supports Intel CPU, GPU, and NPU devices. The
+`device` value in `/etc/gaze/config.toml` selects the device at run time; GPU
+and NPU do not require separate builds. An installation with OpenVINO support
+should set `execution_provider = "openvino"` and `device = "npu"` in its
+installed configuration. If OpenVINO setup fails at run time, Gaze still falls
+back to the ONNX Runtime CPU provider.
+
 ::: warning Build with `just build-rust`, not `cargo build --workspace`
 `just build-rust` builds the daemon and the clients in separate cargo invocations so feature unification cannot link ONNX Runtime into the CLI, GUI, or PAM modules. ONNX Runtime's startup code requires AVX2, and a single workspace build would silently reintroduce crashes on older CPUs.
 :::

--- a/docs/src/guide/development.md
+++ b/docs/src/guide/development.md
@@ -116,6 +116,20 @@ should set `execution_provider = "openvino"` and `device = "npu"` in its
 installed configuration. If OpenVINO setup fails at run time, Gaze still falls
 back to the ONNX Runtime CPU provider.
 
+::: warning OpenVINO is a source build only
+The released `.deb`, `.rpm`, Arch, and Flatpak packages are all produced by
+`just build-rust`, so none of them include OpenVINO. Getting it means building
+from source with `just build-rust-openvino` against your own OpenVINO-enabled
+ONNX Runtime.
+:::
+
+CI does not cover the OpenVINO features either: `just lint`, `just test`, and
+`just build-rust` all build CPU-only. Run `just test-openvino`,
+`just lint-openvino`, and `just build-rust-openvino` by hand before changing
+anything behind the `openvino` or `openvino-config` features. `just test` does
+compile `gaze-core` with `openvino-config` alone, which is what the CLI and GUI
+ship with, but that path needs no OpenVINO runtime.
+
 ::: warning Build with `just build-rust`, not `cargo build --workspace`
 `just build-rust` builds the daemon and the clients in separate cargo invocations so feature unification cannot link ONNX Runtime into the CLI, GUI, or PAM modules. ONNX Runtime's startup code requires AVX2, and a single workspace build would silently reintroduce crashes on older CPUs.
 :::

--- a/docs/src/guide/development.md
+++ b/docs/src/guide/development.md
@@ -95,6 +95,20 @@ just audit        # check dependencies for known CVEs
 just fmt          # apply formatting (fmt-check only checks)
 ```
 
+The default build supports CPU inference only. To build the daemon and
+configuration tools with OpenVINO support, provide an OpenVINO-enabled system
+ONNX Runtime and run:
+
+```bash
+ORT_STRATEGY=system \
+ORT_LIB_LOCATION=/path/to/onnxruntime/lib \
+ORT_PREFER_DYNAMIC_LINK=1 \
+just build-rust-openvino
+```
+
+The `openvino` Cargo feature is explicit. The build fails when that feature is
+enabled without a matching ONNX Runtime library.
+
 ::: warning Build with `just build-rust`, not `cargo build --workspace`
 `just build-rust` builds the daemon and the clients in separate cargo invocations so feature unification cannot link ONNX Runtime into the CLI, GUI, or PAM modules. ONNX Runtime's startup code requires AVX2, and a single workspace build would silently reintroduce crashes on older CPUs.
 :::

--- a/gaze-cli/Cargo.toml
+++ b/gaze-cli/Cargo.toml
@@ -11,6 +11,10 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+openvino = ["gaze-core/openvino-config"]
+
 [[bin]]
 name = "gaze"
 path = "src/main.rs"

--- a/gaze-cli/src/doctor.rs
+++ b/gaze-cli/src/doctor.rs
@@ -391,6 +391,14 @@ fn config_findings(config: &Config) -> Vec<Check> {
             "Set enrollment.min_face_size_ratio to a value from 0.10 through 0.75.",
         );
     }
+    if let Err(err) = config.inference.validate() {
+        let fix = if cfg!(feature = "openvino") {
+            "Use cpu/cpu, openvino/cpu, openvino/gpu, or openvino/npu in the [inference] table."
+        } else {
+            "Use cpu/cpu, or install a Gaze build compiled with the openvino Cargo feature."
+        };
+        error(err.to_string(), fix);
+    }
 
     if config.security.level == "custom" {
         if !config.security.threshold.is_finite()
@@ -464,7 +472,8 @@ fn config_findings(config: &Config) -> Vec<Check> {
         findings.push(Check {
             level: Level::Pass,
             name: "Config values",
-            message: "camera, security, enrollment, and liveness values are valid".to_string(),
+            message: "camera, security, enrollment, inference, and liveness values are valid"
+                .to_string(),
             fix: None,
         });
     }
@@ -1030,8 +1039,14 @@ async fn check_benchmark(report: &mut Report, proxy: &GazeProxy<'_>) {
                 report.pass(
                     "Benchmark",
                     format!(
-                        "{}: {:.1}ms avg ({:.1} fps), {:.1}ms p95, {:.1}ms min",
-                        result.component, result.mean_ms, result.fps, result.p95_ms, result.min_ms
+                        "{} [{} / {}]: {:.1}ms avg ({:.1} fps), {:.1}ms p95, {:.1}ms min",
+                        result.component,
+                        result.execution_provider,
+                        result.device,
+                        result.mean_ms,
+                        result.fps,
+                        result.p95_ms,
+                        result.min_ms
                     ),
                 );
             }

--- a/gaze-cli/src/doctor.rs
+++ b/gaze-cli/src/doctor.rs
@@ -2,6 +2,7 @@ use console::{Term, style};
 use gaze_core::config::{CONFIG_PATH, Config};
 use gaze_core::dbus::{
     GazeProxy, dbus_error_message, dbus_is_file_not_found, dbus_is_not_activatable,
+    try_benchmark_from_daemon,
 };
 use std::collections::BTreeSet;
 use std::ffi::OsStr;
@@ -1030,33 +1031,50 @@ async fn check_benchmark(report: &mut Report, proxy: &GazeProxy<'_>) {
         style("i").cyan().bold()
     ));
 
-    let outcome = tokio::time::timeout(BENCHMARK_TIMEOUT, proxy.benchmark()).await;
+    let outcome = tokio::time::timeout(BENCHMARK_TIMEOUT, try_benchmark_from_daemon(proxy)).await;
     let _ = term.clear_last_lines(1);
 
     match outcome {
-        Ok(Ok(results)) => {
+        Ok(Ok(Some(results))) => {
             for result in results {
-                report.pass(
-                    "Benchmark",
-                    format!(
-                        "{} [{} / {}]: {:.1}ms avg ({:.1} fps), {:.1}ms p95, {:.1}ms min",
-                        result.component,
-                        result.execution_provider,
-                        result.device,
-                        result.mean_ms,
-                        result.fps,
-                        result.p95_ms,
-                        result.min_ms
-                    ),
+                let timings = format!(
+                    "{} [{} / {}]: {:.1}ms avg ({:.1} fps), {:.1}ms p95, {:.1}ms min",
+                    result.component,
+                    result.execution_provider,
+                    result.device,
+                    result.mean_ms,
+                    result.fps,
+                    result.p95_ms,
+                    result.min_ms
                 );
+                if result.ran_as_configured() {
+                    report.pass("Benchmark", timings);
+                } else {
+                    report.warning(
+                        "Benchmark",
+                        format!(
+                            "{timings}; configured {}/{} is not in use: {}",
+                            result.requested_execution_provider,
+                            result.requested_device,
+                            if result.fallback_reason.is_empty() {
+                                "no reason reported"
+                            } else {
+                                result.fallback_reason.as_str()
+                            }
+                        ),
+                        "Check the gazed journal for the OpenVINO setup error, or set [inference] back to cpu/cpu.",
+                    );
+                }
             }
         }
+        Ok(Ok(None)) => report.warning(
+            "Benchmark",
+            "the running daemon reports a benchmark layout this build cannot read",
+            "Restart it with `systemctl restart gazed`.",
+        ),
         Ok(Err(err)) => report.warning(
             "Benchmark",
-            format!(
-                "gazed could not run the benchmark: {}",
-                dbus_error_message(&err)
-            ),
+            format!("gazed could not run the benchmark: {err}"),
             "Restart gazed and inspect its journal.",
         ),
         Err(_) => report.warning(

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -9,7 +9,8 @@ use console::{Term, style};
 use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
 use futures::StreamExt;
 use gaze_core::config::{
-    AuthConfig, Config, HYBRID_POLICY_OPTIONS, MAX_ENROLLMENT_FACE_SIZE_RATIO,
+    AuthConfig, Config, HYBRID_POLICY_OPTIONS, INFERENCE_DEVICE_OPTIONS,
+    INFERENCE_EXECUTION_PROVIDER_OPTIONS, MAX_ENROLLMENT_FACE_SIZE_RATIO,
     MIN_ENROLLMENT_FACE_SIZE_RATIO, MODEL_QUALITY_OPTIONS, SECURITY_LEVEL_OPTIONS, SecurityLevel,
 };
 use gaze_core::dbus::{
@@ -311,6 +312,29 @@ async fn run_config_wizard(
 
         config.security = SecurityLevel::custom(detector, recognizer, threshold, hybrid_policy);
     };
+
+    let selected_execution_provider = Select::with_theme(&theme)
+        .with_prompt("Inference execution provider")
+        .items(INFERENCE_EXECUTION_PROVIDER_OPTIONS)
+        .default(config.inference.execution_provider_index() as usize)
+        .interact()?;
+    config.inference.execution_provider =
+        gaze_core::config::InferenceConfig::execution_provider_from_index(
+            selected_execution_provider,
+        )
+        .to_string();
+
+    if config.inference.execution_provider == "openvino" {
+        let selected_device = Select::with_theme(&theme)
+            .with_prompt("OpenVINO inference device")
+            .items(INFERENCE_DEVICE_OPTIONS)
+            .default(config.inference.device_index() as usize)
+            .interact()?;
+        config.inference.device =
+            gaze_core::config::InferenceConfig::device_from_index(selected_device).to_string();
+    } else {
+        config.inference.device = "cpu".to_string();
+    }
 
     let cameras = gaze_core::camera::enumerate_cameras().unwrap_or_default();
     if cameras.is_empty() {
@@ -1405,6 +1429,16 @@ async fn run() -> anyhow::Result<()> {
         Commands::Config { show } => {
             let config = load_config_from_daemon(&proxy).await?;
             if show {
+                println!(
+                    "{} {}",
+                    style("inference.execution_provider:").bold(),
+                    config.inference.execution_provider
+                );
+                println!(
+                    "{} {}",
+                    style("inference.device:").bold(),
+                    config.inference.device
+                );
                 let level_name = config.security.level.as_str();
                 println!("{} {}", style("security.level:").bold(), level_name);
                 println!(

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -313,27 +313,36 @@ async fn run_config_wizard(
         config.security = SecurityLevel::custom(detector, recognizer, threshold, hybrid_policy);
     };
 
-    let selected_execution_provider = Select::with_theme(&theme)
-        .with_prompt("Inference execution provider")
-        .items(INFERENCE_EXECUTION_PROVIDER_OPTIONS)
-        .default(config.inference.execution_provider_index() as usize)
-        .interact()?;
-    config.inference.execution_provider =
-        gaze_core::config::InferenceConfig::execution_provider_from_index(
-            selected_execution_provider,
-        )
-        .to_string();
-
-    if config.inference.execution_provider == "openvino" {
-        let selected_device = Select::with_theme(&theme)
-            .with_prompt("OpenVINO inference device")
-            .items(INFERENCE_DEVICE_OPTIONS)
-            .default(config.inference.device_index() as usize)
+    if config.inference.is_representable() {
+        let selected_execution_provider = Select::with_theme(&theme)
+            .with_prompt("Inference execution provider")
+            .items(INFERENCE_EXECUTION_PROVIDER_OPTIONS)
+            .default(config.inference.execution_provider_index() as usize)
             .interact()?;
-        config.inference.device =
-            gaze_core::config::InferenceConfig::device_from_index(selected_device).to_string();
+        config.inference.execution_provider =
+            gaze_core::config::InferenceConfig::execution_provider_from_index(
+                selected_execution_provider,
+            )
+            .to_string();
+
+        if config.inference.execution_provider == "openvino" {
+            let selected_device = Select::with_theme(&theme)
+                .with_prompt("OpenVINO inference device")
+                .items(INFERENCE_DEVICE_OPTIONS)
+                .default(config.inference.device_index() as usize)
+                .interact()?;
+            config.inference.device =
+                gaze_core::config::InferenceConfig::device_from_index(selected_device).to_string();
+        } else {
+            config.inference.device = "cpu".to_string();
+        }
     } else {
-        config.inference.device = "cpu".to_string();
+        term.write_line(&format!(
+            "{} Keeping inference {}/{}: this build cannot change it",
+            style("!").yellow().bold(),
+            config.inference.execution_provider,
+            config.inference.device
+        ))?;
     }
 
     let cameras = gaze_core::camera::enumerate_cameras().unwrap_or_default();

--- a/gaze-core/Cargo.toml
+++ b/gaze-core/Cargo.toml
@@ -14,6 +14,8 @@ repository.workspace = true
 [features]
 default = ["detection"]
 detection = ["dep:ort"]
+openvino-config = []
+openvino = ["detection", "openvino-config", "ort/openvino"]
 
 [dependencies]
 anyhow = "1.0.104"

--- a/gaze-core/src/config.rs
+++ b/gaze-core/src/config.rs
@@ -324,6 +324,11 @@ impl InferenceConfig {
         Ok(())
     }
 
+    pub fn is_representable(&self) -> bool {
+        INFERENCE_EXECUTION_PROVIDER_OPTIONS.contains(&self.execution_provider.as_str())
+            && INFERENCE_DEVICE_OPTIONS.contains(&self.device.as_str())
+    }
+
     pub fn execution_provider_index(&self) -> u32 {
         INFERENCE_EXECUTION_PROVIDER_OPTIONS
             .iter()
@@ -819,6 +824,25 @@ mod tests {
             };
             assert!(inference.validate().is_err());
         }
+    }
+
+    #[test]
+    fn a_value_this_build_cannot_show_is_not_representable() {
+        let unknown = InferenceConfig {
+            execution_provider: "webgpu".to_string(),
+            device: "cuda".to_string(),
+        };
+        assert!(!unknown.is_representable());
+        assert!(InferenceConfig::default().is_representable());
+
+        let openvino = InferenceConfig {
+            execution_provider: "openvino".to_string(),
+            device: "npu".to_string(),
+        };
+        assert_eq!(
+            openvino.is_representable(),
+            cfg!(feature = "openvino-config")
+        );
     }
 
     #[test]

--- a/gaze-core/src/config.rs
+++ b/gaze-core/src/config.rs
@@ -13,6 +13,14 @@ pub const SECURITY_LEVEL_OPTIONS: [&str; 5] = ["low", "medium", "high", "maximum
 pub const MODEL_QUALITY_OPTIONS: [&str; 2] = ["standard", "accurate"];
 pub const HYBRID_POLICY_OPTIONS: [&str; 4] = ["default", "or", "fallback_on_dark", "and"];
 pub const START_DELAY_SCOPE_OPTIONS: [&str; 2] = ["all", "screen_lock"];
+#[cfg(not(feature = "openvino-config"))]
+pub const INFERENCE_EXECUTION_PROVIDER_OPTIONS: [&str; 1] = ["cpu"];
+#[cfg(feature = "openvino-config")]
+pub const INFERENCE_EXECUTION_PROVIDER_OPTIONS: [&str; 2] = ["cpu", "openvino"];
+#[cfg(not(feature = "openvino-config"))]
+pub const INFERENCE_DEVICE_OPTIONS: [&str; 1] = ["cpu"];
+#[cfg(feature = "openvino-config")]
+pub const INFERENCE_DEVICE_OPTIONS: [&str; 3] = ["cpu", "gpu", "npu"];
 pub const DEFAULT_ENROLLMENT_MIN_FACE_SIZE_RATIO: f64 = 0.25;
 pub const MIN_ENROLLMENT_FACE_SIZE_RATIO: f64 = 0.10;
 pub const MAX_ENROLLMENT_FACE_SIZE_RATIO: f64 = 0.75;
@@ -246,6 +254,8 @@ impl SecurityLevel {
 #[derive(Deserialize, Serialize, Clone, Debug, Default, Value, OwnedValue, Type)]
 pub struct Config {
     #[serde(default)]
+    pub inference: InferenceConfig,
+    #[serde(default)]
     pub security: SecurityLevel,
     #[serde(default)]
     pub cameras: CameraConfig,
@@ -257,6 +267,92 @@ pub struct Config {
     pub liveness: LivenessConfig,
     #[serde(default)]
     pub storage: StorageConfig,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Value, OwnedValue, Type)]
+pub struct InferenceConfig {
+    #[serde(default = "default_execution_provider")]
+    pub execution_provider: String,
+    #[serde(default = "default_inference_device")]
+    pub device: String,
+}
+
+fn default_execution_provider() -> String {
+    "cpu".to_string()
+}
+
+fn default_inference_device() -> String {
+    "cpu".to_string()
+}
+
+impl Default for InferenceConfig {
+    fn default() -> Self {
+        Self {
+            execution_provider: default_execution_provider(),
+            device: default_inference_device(),
+        }
+    }
+}
+
+impl InferenceConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        #[cfg(not(feature = "openvino-config"))]
+        if self.execution_provider == "openvino" {
+            anyhow::bail!(
+                "this Gaze build does not include OpenVINO support; rebuild with the \"openvino\" Cargo feature"
+            );
+        }
+        if !INFERENCE_EXECUTION_PROVIDER_OPTIONS.contains(&self.execution_provider.as_str()) {
+            anyhow::bail!(
+                "invalid inference.execution_provider {:?}: expected one of {:?}",
+                self.execution_provider,
+                INFERENCE_EXECUTION_PROVIDER_OPTIONS
+            );
+        }
+        if !INFERENCE_DEVICE_OPTIONS.contains(&self.device.as_str()) {
+            anyhow::bail!(
+                "invalid inference.device {:?}: expected one of {:?}",
+                self.device,
+                INFERENCE_DEVICE_OPTIONS
+            );
+        }
+        if self.execution_provider == "cpu" && self.device != "cpu" {
+            anyhow::bail!(
+                "inference.device must be \"cpu\" when inference.execution_provider is \"cpu\""
+            );
+        }
+        Ok(())
+    }
+
+    pub fn execution_provider_index(&self) -> u32 {
+        INFERENCE_EXECUTION_PROVIDER_OPTIONS
+            .iter()
+            .position(|value| *value == self.execution_provider)
+            .map(|index| index as u32)
+            .unwrap_or(0)
+    }
+
+    pub fn device_index(&self) -> u32 {
+        INFERENCE_DEVICE_OPTIONS
+            .iter()
+            .position(|value| *value == self.device)
+            .map(|index| index as u32)
+            .unwrap_or(0)
+    }
+
+    pub fn execution_provider_from_index(index: usize) -> &'static str {
+        INFERENCE_EXECUTION_PROVIDER_OPTIONS
+            .get(index)
+            .copied()
+            .unwrap_or("cpu")
+    }
+
+    pub fn device_from_index(index: usize) -> &'static str {
+        INFERENCE_DEVICE_OPTIONS
+            .get(index)
+            .copied()
+            .unwrap_or("cpu")
+    }
 }
 
 // Its own table: a security preset replaces `[security]` wholesale, resetting it.
@@ -529,6 +625,9 @@ impl Config {
             if let Err(e) = config.enrollment.validate() {
                 tracing::warn!("{e}; using the default enrollment face-size ratio");
             }
+            if let Err(e) = config.inference.validate() {
+                tracing::warn!("{e}; inference configuration will be checked when models load");
+            }
             Ok(config)
         } else {
             Ok(Config::default())
@@ -673,6 +772,56 @@ mod tests {
     }
 
     #[test]
+    fn inference_config_accepts_supported_provider_device_pairs() {
+        #[cfg(feature = "openvino-config")]
+        let supported = [
+            ("cpu", "cpu"),
+            ("openvino", "cpu"),
+            ("openvino", "gpu"),
+            ("openvino", "npu"),
+        ];
+        #[cfg(not(feature = "openvino-config"))]
+        let supported = [("cpu", "cpu")];
+
+        for (execution_provider, device) in supported {
+            let inference = InferenceConfig {
+                execution_provider: execution_provider.to_string(),
+                device: device.to_string(),
+            };
+            inference.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn inference_config_rejects_invalid_pairs() {
+        #[cfg(feature = "openvino-config")]
+        let invalid = [
+            ("cpu", "gpu"),
+            ("cpu", "npu"),
+            ("openvino", "cuda"),
+            ("webgpu", "gpu"),
+        ];
+        #[cfg(not(feature = "openvino-config"))]
+        let invalid = [
+            ("cpu", "gpu"),
+            ("cpu", "npu"),
+            ("openvino", "cuda"),
+            ("webgpu", "gpu"),
+            ("openvino", "cpu"),
+            ("openvino", "gpu"),
+            ("openvino", "npu"),
+        ];
+
+        for (execution_provider, device) in invalid {
+            let inference = InferenceConfig {
+                execution_provider: execution_provider.to_string(),
+                device: device.to_string(),
+            };
+            assert!(inference.validate().is_err());
+        }
+    }
+
+    #[test]
     fn unknown_level_falls_back_to_medium_without_panicking() {
         let mut level = SecurityLevel::medium();
         level.level = "bogus".to_string();
@@ -701,6 +850,8 @@ mod tests {
             config.security.detector(),
             SecurityLevel::medium().detector()
         );
+        assert_eq!(config.inference.execution_provider, "cpu");
+        assert_eq!(config.inference.device, "cpu");
         assert_eq!(config.cameras.rgb, DEFAULT_RGB_CAMERA);
         assert_eq!(config.cameras.dark_luma_threshold, 20);
         assert!(config.auth.abort_if_ssh);
@@ -718,6 +869,10 @@ mod tests {
         let temp = TempDir::new("round-trip");
         let path = temp.path().join("config.toml");
         let config = Config {
+            inference: InferenceConfig {
+                execution_provider: "openvino".to_string(),
+                device: "gpu".to_string(),
+            },
             security: SecurityLevel::high(),
             cameras: CameraConfig {
                 rgb: "primary".to_string(),
@@ -751,6 +906,8 @@ mod tests {
         let loaded = Config::load_from(path.to_str().unwrap()).unwrap();
 
         assert_eq!(loaded.security.detector(), SecurityLevel::high().detector());
+        assert_eq!(loaded.inference.execution_provider, "openvino");
+        assert_eq!(loaded.inference.device, "gpu");
         assert_eq!(
             loaded.security.recognizer(),
             SecurityLevel::high().recognizer()

--- a/gaze-core/src/dbus.rs
+++ b/gaze-core/src/dbus.rs
@@ -122,10 +122,21 @@ pub struct BenchmarkResult {
     pub component: String,
     pub execution_provider: String,
     pub device: String,
+    pub requested_execution_provider: String,
+    pub requested_device: String,
+    pub fallback_reason: String,
     pub mean_ms: f64,
     pub p95_ms: f64,
     pub min_ms: f64,
     pub fps: f64,
+}
+
+impl BenchmarkResult {
+    pub fn ran_as_configured(&self) -> bool {
+        self.fallback_reason.is_empty()
+            && self.execution_provider == self.requested_execution_provider
+            && self.device == self.requested_device
+    }
 }
 
 pub fn dbus_error_message(err: &zbus::Error) -> String {
@@ -148,6 +159,34 @@ pub fn dbus_is_not_activatable(err: &zbus::Error) -> bool {
 pub async fn connect_gaze() -> zbus::Result<GazeProxy<'static>> {
     let connection = zbus::Connection::system().await?;
     GazeProxy::new(&connection).await
+}
+
+pub async fn try_benchmark_from_daemon(
+    proxy: &GazeProxy<'_>,
+) -> anyhow::Result<Option<Vec<BenchmarkResult>>> {
+    let raw: OwnedValue = proxy
+        .inner()
+        .call("Benchmark", &())
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", dbus_error_message(&e)))?;
+    benchmark_from_reply(raw)
+}
+
+pub fn benchmark_from_reply(raw: OwnedValue) -> anyhow::Result<Option<Vec<BenchmarkResult>>> {
+    let expected = <Vec<BenchmarkResult> as Type>::SIGNATURE;
+    let actual = raw.value_signature();
+    if actual != expected {
+        tracing::warn!(
+            %actual,
+            %expected,
+            "daemon benchmark layout does not match this build; restart gazed"
+        );
+        return Ok(None);
+    }
+
+    Vec::<BenchmarkResult>::try_from(raw)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("Failed to decode benchmark results: {}", e))
 }
 
 pub async fn try_load_config_from_daemon(proxy: &GazeProxy<'_>) -> anyhow::Result<Option<Config>> {
@@ -290,6 +329,65 @@ pub trait Gaze {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Clone, Debug, Value, OwnedValue, Type)]
+    struct OldBenchmarkResult {
+        component: String,
+        mean_ms: f64,
+        p95_ms: f64,
+        min_ms: f64,
+        fps: f64,
+    }
+
+    fn benchmark_result(requested_device: &str, fallback_reason: &str) -> BenchmarkResult {
+        BenchmarkResult {
+            component: "Face detector".to_string(),
+            execution_provider: "cpu".to_string(),
+            device: "cpu".to_string(),
+            requested_execution_provider: "cpu".to_string(),
+            requested_device: requested_device.to_string(),
+            fallback_reason: fallback_reason.to_string(),
+            mean_ms: 1.0,
+            p95_ms: 2.0,
+            min_ms: 0.5,
+            fps: 1000.0,
+        }
+    }
+
+    #[test]
+    fn current_benchmark_layout_decodes() {
+        let raw = OwnedValue::try_from(Value::from(vec![benchmark_result("cpu", "")])).unwrap();
+        let decoded = benchmark_from_reply(raw)
+            .expect("no error")
+            .expect("current layout is readable");
+
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].ran_as_configured());
+    }
+
+    #[test]
+    fn older_daemon_benchmark_layout_is_reported_not_decoded() {
+        let old = vec![OldBenchmarkResult {
+            component: "Face detector".to_string(),
+            mean_ms: 1.0,
+            p95_ms: 2.0,
+            min_ms: 0.5,
+            fps: 1000.0,
+        }];
+        let raw = OwnedValue::try_from(Value::from(old)).expect("old results convert to a value");
+
+        assert!(
+            benchmark_from_reply(raw)
+                .expect("a layout mismatch is not an error")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_device_fallback_is_not_reported_as_configured() {
+        assert!(!benchmark_result("npu", "no npu driver").ran_as_configured());
+        assert!(!benchmark_result("npu", "").ran_as_configured());
+    }
 
     #[test]
     fn enum_display_strings_are_user_facing_messages() {

--- a/gaze-core/src/dbus.rs
+++ b/gaze-core/src/dbus.rs
@@ -120,6 +120,8 @@ pub enum VerifyResult {
 #[derive(Clone, Debug, Serialize, Deserialize, Value, OwnedValue, Type)]
 pub struct BenchmarkResult {
     pub component: String,
+    pub execution_provider: String,
+    pub device: String,
     pub mean_ms: f64,
     pub p95_ms: f64,
     pub min_ms: f64,

--- a/gaze-core/src/dbus.rs
+++ b/gaze-core/src/dbus.rs
@@ -406,19 +406,10 @@ mod tests {
     }
 
     #[derive(Clone, Debug, Value, OwnedValue, Type)]
-    struct OldAuthConfig {
-        abort_if_ssh: bool,
-        abort_if_lid_closed: bool,
-        require_confirmation: bool,
-        resume_grace_ms: u64,
-        start_delay_ms: u64,
-    }
-
-    #[derive(Clone, Debug, Value, OwnedValue, Type)]
     struct OldConfig {
         security: crate::config::SecurityLevel,
         cameras: crate::config::CameraConfig,
-        auth: OldAuthConfig,
+        auth: crate::config::AuthConfig,
         enrollment: crate::config::EnrollmentConfig,
         liveness: crate::config::LivenessConfig,
         storage: crate::config::StorageConfig,
@@ -428,13 +419,7 @@ mod tests {
         let old = OldConfig {
             security: Default::default(),
             cameras: Default::default(),
-            auth: OldAuthConfig {
-                abort_if_ssh: true,
-                abort_if_lid_closed: true,
-                require_confirmation: false,
-                resume_grace_ms: 0,
-                start_delay_ms: 3000,
-            },
+            auth: Default::default(),
             enrollment: Default::default(),
             liveness: Default::default(),
             storage: Default::default(),

--- a/gaze-core/src/detect.rs
+++ b/gaze-core/src/detect.rs
@@ -1,7 +1,12 @@
 use opencv::core::Mat;
 use opencv::prelude::*;
-use ort::{session::Session, session::builder::GraphOptimizationLevel, value::TensorRef};
+use ort::{session::Session, value::TensorRef};
 use std::fmt;
+
+use crate::{
+    config::InferenceConfig,
+    inference::{InferenceRuntime, create_session},
+};
 
 #[derive(Debug)]
 pub enum DetectError {
@@ -50,6 +55,7 @@ pub type DetectResult = (ndarray::Array2<f32>, Option<ndarray::Array3<f32>>, Mat
 
 pub struct FaceDetector {
     session: Session,
+    inference_runtime: InferenceRuntime,
     input_size: (usize, usize), // (width, height)
     conf_threshold: f32,
     iou_threshold: f32,
@@ -57,18 +63,27 @@ pub struct FaceDetector {
 
 impl FaceDetector {
     pub fn new(model_path: &str) -> Result<Self, DetectError> {
-        let session = Session::builder()
-            .map_err(|e| DetectError::InitFailed(e.to_string()))?
-            .with_optimization_level(GraphOptimizationLevel::Level3)
-            .map_err(|e| DetectError::InitFailed(e.to_string()))?
-            .commit_from_file(model_path)?;
+        Self::new_with_inference(model_path, &InferenceConfig::default())
+    }
+
+    pub fn new_with_inference(
+        model_path: &str,
+        inference: &InferenceConfig,
+    ) -> Result<Self, DetectError> {
+        let (session, inference_runtime) = create_session(model_path, inference)
+            .map_err(|error| DetectError::InitFailed(error.to_string()))?;
 
         Ok(Self {
             session,
+            inference_runtime,
             input_size: (320, 320),
             conf_threshold: 0.1,
             iou_threshold: 0.4,
         })
+    }
+
+    pub fn inference_runtime(&self) -> &InferenceRuntime {
+        &self.inference_runtime
     }
 
     pub fn pad_to_square(img: &Mat) -> Result<Mat, DetectError> {

--- a/gaze-core/src/detect.rs
+++ b/gaze-core/src/detect.rs
@@ -62,10 +62,6 @@ pub struct FaceDetector {
 }
 
 impl FaceDetector {
-    pub fn new(model_path: &str) -> Result<Self, DetectError> {
-        Self::new_with_inference(model_path, &InferenceConfig::default())
-    }
-
     pub fn new_with_inference(
         model_path: &str,
         inference: &InferenceConfig,

--- a/gaze-core/src/inference.rs
+++ b/gaze-core/src/inference.rs
@@ -1,0 +1,168 @@
+use crate::config::InferenceConfig;
+use anyhow::Context;
+#[cfg(feature = "openvino")]
+use ort::ep;
+use ort::session::{Session, builder::GraphOptimizationLevel};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InferenceRuntime {
+    pub requested_execution_provider: String,
+    pub requested_device: String,
+    pub active_execution_provider: String,
+    pub active_device: String,
+    pub fallback_reason: Option<String>,
+}
+
+impl InferenceRuntime {
+    fn cpu(config: &InferenceConfig, fallback_reason: Option<String>) -> Self {
+        Self {
+            requested_execution_provider: config.execution_provider.clone(),
+            requested_device: config.device.clone(),
+            active_execution_provider: "cpu".to_string(),
+            active_device: "cpu".to_string(),
+            fallback_reason,
+        }
+    }
+
+    #[cfg(feature = "openvino")]
+    fn openvino(config: &InferenceConfig) -> Self {
+        Self {
+            requested_execution_provider: config.execution_provider.clone(),
+            requested_device: config.device.clone(),
+            active_execution_provider: "openvino".to_string(),
+            active_device: config.device.clone(),
+            fallback_reason: None,
+        }
+    }
+}
+
+fn build_cpu_session(model_path: &str) -> anyhow::Result<Session> {
+    Session::builder()
+        .map_err(|error| {
+            anyhow::anyhow!("failed to create an ONNX Runtime session builder: {error}")
+        })?
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .map_err(|error| {
+            anyhow::anyhow!("failed to set the ONNX Runtime graph optimization level: {error}")
+        })?
+        .commit_from_file(model_path)
+        .with_context(|| format!("failed to load ONNX model {model_path} on cpu"))
+}
+
+#[cfg(feature = "openvino")]
+fn build_openvino_session(model_path: &str, device: &str) -> anyhow::Result<Session> {
+    let openvino_device = device.to_ascii_uppercase();
+    Session::builder()
+        .map_err(|error| {
+            anyhow::anyhow!("failed to create an ONNX Runtime session builder: {error}")
+        })?
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .map_err(|error| {
+            anyhow::anyhow!("failed to set the ONNX Runtime graph optimization level: {error}")
+        })?
+        .with_execution_providers([ep::OpenVINO::default()
+            .with_device_type(&openvino_device)
+            .build()
+            .error_on_failure()])
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "failed to register the OpenVINO Execution Provider for {device}: {error}"
+            )
+        })?
+        .commit_from_file(model_path)
+        .with_context(|| format!("failed to load ONNX model {model_path} on {device}"))
+}
+
+pub fn create_session(
+    model_path: &str,
+    config: &InferenceConfig,
+) -> anyhow::Result<(Session, InferenceRuntime)> {
+    #[cfg(not(feature = "openvino"))]
+    if config.execution_provider == "openvino" {
+        anyhow::bail!(
+            "this Gaze build does not include OpenVINO support; rebuild with the \"openvino\" Cargo feature"
+        );
+    }
+
+    if let Err(error) = config.validate() {
+        let reason = error.to_string();
+        tracing::warn!(
+            reason,
+            "Invalid inference configuration; falling back to the ONNX Runtime CPU execution provider"
+        );
+        let session = build_cpu_session(model_path)?;
+        return Ok((session, InferenceRuntime::cpu(config, Some(reason))));
+    }
+
+    #[cfg(feature = "openvino")]
+    if config.execution_provider == "openvino" {
+        match build_openvino_session(model_path, &config.device) {
+            Ok(session) => {
+                tracing::info!(
+                    execution_provider = "openvino",
+                    device = config.device,
+                    model = model_path,
+                    "Loaded ONNX model"
+                );
+                return Ok((session, InferenceRuntime::openvino(config)));
+            }
+            Err(error) => {
+                let reason = error.to_string();
+                tracing::warn!(
+                    execution_provider = "openvino",
+                    device = config.device,
+                    model = model_path,
+                    reason,
+                    "OpenVINO model setup failed; falling back to the ONNX Runtime CPU execution provider"
+                );
+                let session = build_cpu_session(model_path).with_context(|| {
+                    format!(
+                        "OpenVINO setup failed ({reason}) and the ONNX Runtime CPU fallback also failed"
+                    )
+                })?;
+                return Ok((session, InferenceRuntime::cpu(config, Some(reason))));
+            }
+        }
+    }
+
+    let session = build_cpu_session(model_path)?;
+    tracing::info!(
+        execution_provider = "cpu",
+        device = "cpu",
+        model = model_path,
+        "Loaded ONNX model"
+    );
+    Ok((session, InferenceRuntime::cpu(config, None)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "openvino")]
+    fn runtime_names_remain_lowercase() {
+        let config = InferenceConfig {
+            execution_provider: "openvino".to_string(),
+            device: "gpu".to_string(),
+        };
+        let runtime = InferenceRuntime::openvino(&config);
+        assert_eq!(runtime.active_execution_provider, "openvino");
+        assert_eq!(runtime.active_device, "gpu");
+    }
+
+    #[test]
+    #[cfg(not(feature = "openvino"))]
+    fn cpu_only_build_rejects_openvino_before_loading_a_model() {
+        let config = InferenceConfig {
+            execution_provider: "openvino".to_string(),
+            device: "gpu".to_string(),
+        };
+        let error = create_session("/model-does-not-exist.onnx", &config).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not include OpenVINO support")
+        );
+    }
+}

--- a/gaze-core/src/inference.rs
+++ b/gaze-core/src/inference.rs
@@ -73,22 +73,26 @@ fn build_openvino_session(model_path: &str, device: &str) -> anyhow::Result<Sess
         .with_context(|| format!("failed to load ONNX model {model_path} on {device}"))
 }
 
+fn unusable_reason(config: &InferenceConfig) -> Option<String> {
+    #[cfg(not(feature = "openvino"))]
+    if config.execution_provider == "openvino" {
+        return Some(
+            "this Gaze build does not include OpenVINO support; rebuild with the \"openvino\" Cargo feature"
+                .to_string(),
+        );
+    }
+
+    config.validate().err().map(|error| error.to_string())
+}
+
 pub fn create_session(
     model_path: &str,
     config: &InferenceConfig,
 ) -> anyhow::Result<(Session, InferenceRuntime)> {
-    #[cfg(not(feature = "openvino"))]
-    if config.execution_provider == "openvino" {
-        anyhow::bail!(
-            "this Gaze build does not include OpenVINO support; rebuild with the \"openvino\" Cargo feature"
-        );
-    }
-
-    if let Err(error) = config.validate() {
-        let reason = error.to_string();
+    if let Some(reason) = unusable_reason(config) {
         tracing::warn!(
             reason,
-            "Invalid inference configuration; falling back to the ONNX Runtime CPU execution provider"
+            "Unusable inference configuration; falling back to the ONNX Runtime CPU execution provider"
         );
         let session = build_cpu_session(model_path)?;
         return Ok((session, InferenceRuntime::cpu(config, Some(reason))));
@@ -153,16 +157,27 @@ mod tests {
 
     #[test]
     #[cfg(not(feature = "openvino"))]
-    fn cpu_only_build_rejects_openvino_before_loading_a_model() {
+    fn cpu_only_build_falls_back_for_openvino_instead_of_refusing_to_start() {
         let config = InferenceConfig {
             execution_provider: "openvino".to_string(),
             device: "gpu".to_string(),
         };
-        let error = create_session("/model-does-not-exist.onnx", &config).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("does not include OpenVINO support")
-        );
+        let reason = unusable_reason(&config).expect("a cpu-only build cannot honour openvino");
+        assert!(reason.contains("does not include OpenVINO support"));
+    }
+
+    #[test]
+    fn a_usable_cpu_configuration_has_no_fallback_reason() {
+        assert_eq!(unusable_reason(&InferenceConfig::default()), None);
+    }
+
+    #[test]
+    fn an_invalid_device_falls_back_rather_than_failing() {
+        let config = InferenceConfig {
+            execution_provider: "cpu".to_string(),
+            device: "npu".to_string(),
+        };
+        let reason = unusable_reason(&config).expect("cpu cannot drive an npu");
+        assert!(reason.contains("inference.device"));
     }
 }

--- a/gaze-core/src/lib.rs
+++ b/gaze-core/src/lib.rs
@@ -6,4 +6,6 @@ pub mod dbus;
 pub mod detect;
 #[cfg(feature = "detection")]
 pub mod face;
+#[cfg(feature = "detection")]
+pub mod inference;
 pub mod ir;

--- a/gaze-gui/Cargo.toml
+++ b/gaze-gui/Cargo.toml
@@ -11,6 +11,10 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+openvino = ["gaze-core/openvino-config"]
+
 [[bin]]
 name = "gaze-gui"
 path = "src/main.rs"

--- a/gaze-gui/src/window.rs
+++ b/gaze-gui/src/window.rs
@@ -1,6 +1,7 @@
 use crate::capture_dialog;
 use gaze_core::config::{
-    AuthConfig, Config, DEFAULT_RGB_CAMERA, MAX_ENROLLMENT_FACE_SIZE_RATIO,
+    AuthConfig, Config, DEFAULT_RGB_CAMERA, INFERENCE_DEVICE_OPTIONS,
+    INFERENCE_EXECUTION_PROVIDER_OPTIONS, InferenceConfig, MAX_ENROLLMENT_FACE_SIZE_RATIO,
     MIN_ENROLLMENT_FACE_SIZE_RATIO, SecurityLevel,
 };
 use gaze_core::dbus::{
@@ -97,7 +98,16 @@ fn set_liveness_config_rows_visible(
     max_frames_row.set_visible(active);
 }
 
+fn set_inference_device_row_visible(
+    execution_provider_row: &libadwaita::ComboRow,
+    device_row: &libadwaita::ComboRow,
+) {
+    device_row.set_visible(execution_provider_row.selected() == 1);
+}
+
 struct ConfigRows<'a> {
+    inference_execution_provider: &'a libadwaita::ComboRow,
+    inference_device: &'a libadwaita::ComboRow,
     level: &'a libadwaita::ComboRow,
     detector: &'a libadwaita::ComboRow,
     recognizer: &'a libadwaita::ComboRow,
@@ -127,6 +137,12 @@ struct CameraChoices<'a> {
 }
 
 fn populate_config_rows(cfg: &Config, rows: ConfigRows<'_>, choices: CameraChoices<'_>) {
+    rows.inference_execution_provider
+        .set_selected(cfg.inference.execution_provider_index());
+    rows.inference_device
+        .set_selected(cfg.inference.device_index());
+    set_inference_device_row_visible(rows.inference_execution_provider, rows.inference_device);
+
     rows.level.set_selected(cfg.security.level_index());
     set_custom_config_rows_visible(
         rows.level,
@@ -258,6 +274,21 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
     let hardware_group = libadwaita::PreferencesGroup::new();
     hardware_group.set_title("Hardware");
     page.add(&hardware_group);
+
+    let inference_execution_provider_row = libadwaita::ComboRow::new();
+    inference_execution_provider_row.set_title("Inference execution provider");
+    inference_execution_provider_row.set_subtitle("Use ONNX Runtime directly or through OpenVINO");
+    let inference_execution_provider_model =
+        gtk4::StringList::new(&INFERENCE_EXECUTION_PROVIDER_OPTIONS);
+    inference_execution_provider_row.set_model(Some(&inference_execution_provider_model));
+    hardware_group.add(&inference_execution_provider_row);
+
+    let inference_device_row = libadwaita::ComboRow::new();
+    inference_device_row.set_title("OpenVINO inference device");
+    inference_device_row.set_subtitle("The Intel device used for all ONNX models");
+    let inference_device_model = gtk4::StringList::new(&INFERENCE_DEVICE_OPTIONS);
+    inference_device_row.set_model(Some(&inference_device_model));
+    hardware_group.add(&inference_device_row);
 
     let cameras = gaze_core::camera::enumerate_cameras()
         .unwrap_or_else(|_| vec![("Primary Camera".to_string(), DEFAULT_RGB_CAMERA.to_string())]);
@@ -444,9 +475,21 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         }
     ));
 
+    inference_execution_provider_row.connect_selected_notify(glib::clone!(
+        #[weak]
+        inference_device_row,
+        move |row| {
+            set_inference_device_row_visible(row, &inference_device_row);
+        }
+    ));
+
     let apply_changes = glib::clone!(
         #[weak]
         overlay,
+        #[weak]
+        inference_execution_provider_row,
+        #[weak]
+        inference_device_row,
         #[weak]
         level_row,
         #[weak]
@@ -503,6 +546,16 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
             }
 
             let mut cfg = config.borrow_mut();
+            cfg.inference.execution_provider = InferenceConfig::execution_provider_from_index(
+                inference_execution_provider_row.selected() as usize,
+            )
+            .to_string();
+            cfg.inference.device = if cfg.inference.execution_provider == "openvino" {
+                InferenceConfig::device_from_index(inference_device_row.selected() as usize)
+                    .to_string()
+            } else {
+                "cpu".to_string()
+            };
             let hybrid_idx = hybrid_row.selected() as usize;
             let hybrid_policy = SecurityLevel::hybrid_policy_from_index(hybrid_idx);
 
@@ -570,6 +623,16 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         }
     );
 
+    inference_execution_provider_row.connect_selected_notify(glib::clone!(
+        #[strong]
+        apply_changes,
+        move |_| apply_changes()
+    ));
+    inference_device_row.connect_selected_notify(glib::clone!(
+        #[strong]
+        apply_changes,
+        move |_| apply_changes()
+    ));
     level_row.connect_selected_notify(glib::clone!(
         #[strong]
         apply_changes,
@@ -688,6 +751,8 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
         populate_config_rows(
             &cfg,
             ConfigRows {
+                inference_execution_provider: &inference_execution_provider_row,
+                inference_device: &inference_device_row,
                 level: &level_row,
                 detector: &detector_row,
                 recognizer: &recognizer_row,
@@ -830,6 +895,10 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
 
     glib::MainContext::default().spawn_local(glib::clone!(
         #[weak]
+        inference_execution_provider_row,
+        #[weak]
+        inference_device_row,
+        #[weak]
         level_row,
         #[weak]
         detector_row,
@@ -891,6 +960,8 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
                 populate_config_rows(
                     &cfg,
                     ConfigRows {
+                        inference_execution_provider: &inference_execution_provider_row,
+                        inference_device: &inference_device_row,
                         level: &level_row,
                         detector: &detector_row,
                         recognizer: &recognizer_row,

--- a/gaze-gui/src/window.rs
+++ b/gaze-gui/src/window.rs
@@ -102,7 +102,9 @@ fn set_inference_device_row_visible(
     execution_provider_row: &libadwaita::ComboRow,
     device_row: &libadwaita::ComboRow,
 ) {
-    device_row.set_visible(execution_provider_row.selected() == 1);
+    let provider =
+        InferenceConfig::execution_provider_from_index(execution_provider_row.selected() as usize);
+    device_row.set_visible(provider == "openvino");
 }
 
 struct ConfigRows<'a> {
@@ -141,6 +143,15 @@ fn populate_config_rows(cfg: &Config, rows: ConfigRows<'_>, choices: CameraChoic
         .set_selected(cfg.inference.execution_provider_index());
     rows.inference_device
         .set_selected(cfg.inference.device_index());
+    if cfg.inference.is_representable() {
+        rows.inference_execution_provider
+            .set_subtitle("Use ONNX Runtime directly or through OpenVINO");
+    } else {
+        rows.inference_execution_provider.set_subtitle(&format!(
+            "Configured as {}/{}, which this build cannot show",
+            cfg.inference.execution_provider, cfg.inference.device
+        ));
+    }
     set_inference_device_row_visible(rows.inference_execution_provider, rows.inference_device);
 
     rows.level.set_selected(cfg.security.level_index());
@@ -454,6 +465,7 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
     ));
 
     let is_loading = Rc::new(std::cell::Cell::new(true));
+    let inference_touched = Rc::new(std::cell::Cell::new(false));
 
     level_row.connect_selected_notify(glib::clone!(
         #[weak]
@@ -484,6 +496,8 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
     ));
 
     let apply_changes = glib::clone!(
+        #[strong]
+        inference_touched,
         #[weak]
         overlay,
         #[weak]
@@ -546,16 +560,18 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
             }
 
             let mut cfg = config.borrow_mut();
-            cfg.inference.execution_provider = InferenceConfig::execution_provider_from_index(
-                inference_execution_provider_row.selected() as usize,
-            )
-            .to_string();
-            cfg.inference.device = if cfg.inference.execution_provider == "openvino" {
-                InferenceConfig::device_from_index(inference_device_row.selected() as usize)
-                    .to_string()
-            } else {
-                "cpu".to_string()
-            };
+            if inference_touched.get() || cfg.inference.is_representable() {
+                cfg.inference.execution_provider = InferenceConfig::execution_provider_from_index(
+                    inference_execution_provider_row.selected() as usize,
+                )
+                .to_string();
+                cfg.inference.device = if cfg.inference.execution_provider == "openvino" {
+                    InferenceConfig::device_from_index(inference_device_row.selected() as usize)
+                        .to_string()
+                } else {
+                    "cpu".to_string()
+                };
+            }
             let hybrid_idx = hybrid_row.selected() as usize;
             let hybrid_policy = SecurityLevel::hybrid_policy_from_index(hybrid_idx);
 
@@ -626,12 +642,30 @@ fn show_config_dialog(parent: &libadwaita::ApplicationWindow, overlay: &libadwai
     inference_execution_provider_row.connect_selected_notify(glib::clone!(
         #[strong]
         apply_changes,
-        move |_| apply_changes()
+        #[strong]
+        inference_touched,
+        #[strong]
+        is_loading,
+        move |_| {
+            if !is_loading.get() {
+                inference_touched.set(true);
+            }
+            apply_changes()
+        }
     ));
     inference_device_row.connect_selected_notify(glib::clone!(
         #[strong]
         apply_changes,
-        move |_| apply_changes()
+        #[strong]
+        inference_touched,
+        #[strong]
+        is_loading,
+        move |_| {
+            if !is_loading.get() {
+                inference_touched.set(true);
+            }
+            apply_changes()
+        }
     ));
     level_row.connect_selected_notify(glib::clone!(
         #[strong]

--- a/gaze/Cargo.toml
+++ b/gaze/Cargo.toml
@@ -11,6 +11,10 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+openvino = ["gaze-core/openvino", "ort/openvino"]
+
 [dependencies]
 aes-gcm = "0.11.0"
 anyhow = "1.0.104"

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -1227,6 +1227,7 @@ const BENCHMARK_TIMED_ITERS: usize = 15;
 
 fn benchmark_component(
     component: &str,
+    runtime: &gaze_core::inference::InferenceRuntime,
     mut run_once: impl FnMut() -> anyhow::Result<()>,
 ) -> anyhow::Result<gaze_core::dbus::BenchmarkResult> {
     for _ in 0..BENCHMARK_WARMUP_ITERS {
@@ -1249,6 +1250,8 @@ fn benchmark_component(
 
     Ok(gaze_core::dbus::BenchmarkResult {
         component: component.to_string(),
+        execution_provider: runtime.active_execution_provider.clone(),
+        device: runtime.active_device.clone(),
         mean_ms,
         p95_ms,
         min_ms,
@@ -1266,7 +1269,13 @@ fn run_inference_benchmark(
 
     {
         let mut detector = detector.lock().unwrap_or_else(|e| e.into_inner());
-        let result = benchmark_component("Face detector", || Ok(detector.benchmark_infer()?))
+        let runtime = detector.inference_runtime().clone();
+        let result =
+            benchmark_component(
+                "Face detector",
+                &runtime,
+                || Ok(detector.benchmark_infer()?),
+            )
             .map_err(|e| fdo::Error::Failed(format!("detector benchmark failed: {e}")))?;
         results.push(result);
     }
@@ -1275,7 +1284,8 @@ fn run_inference_benchmark(
 
     {
         let mut recognizer = recognizer_rgb.blocking_lock();
-        let result = benchmark_component("Face recognizer (RGB)", || {
+        let runtime = recognizer.inference_runtime().clone();
+        let result = benchmark_component("Face recognizer (RGB)", &runtime, || {
             recognizer.get_embedding(&synthetic_face).map(|_| ())
         })
         .map_err(|e| fdo::Error::Failed(format!("RGB recognizer benchmark failed: {e}")))?;
@@ -1284,7 +1294,8 @@ fn run_inference_benchmark(
 
     {
         let mut recognizer = recognizer_ir.blocking_lock();
-        let result = benchmark_component("Face recognizer (IR)", || {
+        let runtime = recognizer.inference_runtime().clone();
+        let result = benchmark_component("Face recognizer (IR)", &runtime, || {
             recognizer.get_embedding(&synthetic_face).map(|_| ())
         })
         .map_err(|e| fdo::Error::Failed(format!("IR recognizer benchmark failed: {e}")))?;
@@ -1294,7 +1305,8 @@ fn run_inference_benchmark(
     {
         let mut liveness_guard = liveness.blocking_lock();
         if let Some(detector) = liveness_guard.as_mut() {
-            let result = benchmark_component("Liveness (MiniFASNet)", || {
+            let runtime = detector.inference_runtime().clone();
+            let result = benchmark_component("Liveness (MiniFASNet)", &runtime, || {
                 detector.live_score(&synthetic_face).map(|_| ())
             })
             .map_err(|e| fdo::Error::Failed(format!("liveness benchmark failed: {e}")))?;
@@ -1308,11 +1320,19 @@ fn run_inference_benchmark(
 #[cfg(test)]
 mod benchmark_tests {
     use super::{BENCHMARK_TIMED_ITERS, BENCHMARK_WARMUP_ITERS, benchmark_component};
+    use gaze_core::inference::InferenceRuntime;
 
     #[test]
     fn runs_warmup_then_timed_iterations_and_reports_ordered_stats() {
         let calls = std::cell::Cell::new(0usize);
-        let result = benchmark_component("Test model", || {
+        let runtime = InferenceRuntime {
+            requested_execution_provider: "cpu".to_string(),
+            requested_device: "cpu".to_string(),
+            active_execution_provider: "cpu".to_string(),
+            active_device: "cpu".to_string(),
+            fallback_reason: None,
+        };
+        let result = benchmark_component("Test model", &runtime, || {
             calls.set(calls.get() + 1);
             Ok(())
         })
@@ -1327,7 +1347,15 @@ mod benchmark_tests {
 
     #[test]
     fn propagates_the_first_error_from_warmup() {
-        let err = benchmark_component("Failing model", || anyhow::bail!("boom")).unwrap_err();
+        let runtime = InferenceRuntime {
+            requested_execution_provider: "cpu".to_string(),
+            requested_device: "cpu".to_string(),
+            active_execution_provider: "cpu".to_string(),
+            active_device: "cpu".to_string(),
+            fallback_reason: None,
+        };
+        let err =
+            benchmark_component("Failing model", &runtime, || anyhow::bail!("boom")).unwrap_err();
         assert!(err.to_string().contains("boom"));
     }
 }
@@ -2223,6 +2251,10 @@ impl AuthDaemon {
             .enrollment
             .validate()
             .map_err(|e| fdo::Error::InvalidArgs(e.to_string()))?;
+        new_config
+            .inference
+            .validate()
+            .map_err(|e| fdo::Error::InvalidArgs(e.to_string()))?;
 
         self.cancel_active_tasks().await;
 
@@ -2230,9 +2262,10 @@ impl AuthDaemon {
             let path = crate::models::ensure_liveness_model(gaze_core::config::MODELS_DIR)
                 .map_err(|e| fdo::Error::Failed(format!("Failed to ensure liveness model: {e}")))?;
             Some(
-                LivenessDetector::new(path.to_str().unwrap()).map_err(|e| {
-                    fdo::Error::Failed(format!("Failed to load liveness model: {e}"))
-                })?,
+                LivenessDetector::new_with_inference(path.to_str().unwrap(), &new_config.inference)
+                    .map_err(|e| {
+                        fdo::Error::Failed(format!("Failed to load liveness model: {e}"))
+                    })?,
             )
         } else {
             None
@@ -2272,6 +2305,8 @@ impl AuthDaemon {
         info!(
             detector = security.detector(),
             recognizer = security.recognizer(),
+            execution_provider = new_config.inference.execution_provider,
+            device = new_config.inference.device,
             "Hot-reloading models if needed"
         );
 
@@ -2286,7 +2321,10 @@ impl AuthDaemon {
 
         {
             let mut detector = self.detector.lock().unwrap_or_else(|e| e.into_inner());
-            match gaze_core::detect::FaceDetector::new(det_path.to_str().unwrap()) {
+            match gaze_core::detect::FaceDetector::new_with_inference(
+                det_path.to_str().unwrap(),
+                &new_config.inference,
+            ) {
                 Ok(det) => {
                     *detector = det;
                 }
@@ -2299,17 +2337,22 @@ impl AuthDaemon {
         {
             let mut recognizer_rgb = self.recognizer_rgb.lock().await;
             let mut recognizer_ir = self.recognizer_ir.lock().await;
-            match crate::recognize::FaceRecognizer::new(rec_path.to_str().unwrap()) {
+            match crate::recognize::FaceRecognizer::new_with_inference(
+                rec_path.to_str().unwrap(),
+                &new_config.inference,
+            ) {
                 Ok(rec_rgb) => {
-                    let rec_ir =
-                        match crate::recognize::FaceRecognizer::new(rec_path.to_str().unwrap()) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                return Err(fdo::Error::Failed(format!(
-                                    "Failed to load IR recognizer: {e}"
-                                )));
-                            }
-                        };
+                    let rec_ir = match crate::recognize::FaceRecognizer::new_with_inference(
+                        rec_path.to_str().unwrap(),
+                        &new_config.inference,
+                    ) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            return Err(fdo::Error::Failed(format!(
+                                "Failed to load IR recognizer: {e}"
+                            )));
+                        }
+                    };
                     *recognizer_rgb = rec_rgb;
                     *recognizer_ir = rec_ir;
                 }

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -1252,6 +1252,9 @@ fn benchmark_component(
         component: component.to_string(),
         execution_provider: runtime.active_execution_provider.clone(),
         device: runtime.active_device.clone(),
+        requested_execution_provider: runtime.requested_execution_provider.clone(),
+        requested_device: runtime.requested_device.clone(),
+        fallback_reason: runtime.fallback_reason.clone().unwrap_or_default(),
         mean_ms,
         p95_ms,
         min_ms,
@@ -1322,16 +1325,20 @@ mod benchmark_tests {
     use super::{BENCHMARK_TIMED_ITERS, BENCHMARK_WARMUP_ITERS, benchmark_component};
     use gaze_core::inference::InferenceRuntime;
 
-    #[test]
-    fn runs_warmup_then_timed_iterations_and_reports_ordered_stats() {
-        let calls = std::cell::Cell::new(0usize);
-        let runtime = InferenceRuntime {
+    fn cpu_runtime() -> InferenceRuntime {
+        InferenceRuntime {
             requested_execution_provider: "cpu".to_string(),
             requested_device: "cpu".to_string(),
             active_execution_provider: "cpu".to_string(),
             active_device: "cpu".to_string(),
             fallback_reason: None,
-        };
+        }
+    }
+
+    #[test]
+    fn runs_warmup_then_timed_iterations_and_reports_ordered_stats() {
+        let calls = std::cell::Cell::new(0usize);
+        let runtime = cpu_runtime();
         let result = benchmark_component("Test model", &runtime, || {
             calls.set(calls.get() + 1);
             Ok(())
@@ -1340,6 +1347,7 @@ mod benchmark_tests {
 
         assert_eq!(calls.get(), BENCHMARK_WARMUP_ITERS + BENCHMARK_TIMED_ITERS);
         assert_eq!(result.component, "Test model");
+        assert!(result.ran_as_configured());
         assert!(result.min_ms <= result.mean_ms);
         assert!(result.min_ms <= result.p95_ms);
         assert!(result.fps >= 0.0);
@@ -1347,16 +1355,27 @@ mod benchmark_tests {
 
     #[test]
     fn propagates_the_first_error_from_warmup() {
-        let runtime = InferenceRuntime {
-            requested_execution_provider: "cpu".to_string(),
-            requested_device: "cpu".to_string(),
-            active_execution_provider: "cpu".to_string(),
-            active_device: "cpu".to_string(),
-            fallback_reason: None,
-        };
+        let runtime = cpu_runtime();
         let err =
             benchmark_component("Failing model", &runtime, || anyhow::bail!("boom")).unwrap_err();
         assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn reports_the_fallback_when_the_requested_device_is_not_in_use() {
+        let runtime = InferenceRuntime {
+            requested_execution_provider: "openvino".to_string(),
+            requested_device: "npu".to_string(),
+            active_execution_provider: "cpu".to_string(),
+            active_device: "cpu".to_string(),
+            fallback_reason: Some("no npu driver".to_string()),
+        };
+        let result = benchmark_component("Test model", &runtime, || Ok(())).unwrap();
+
+        assert!(!result.ran_as_configured());
+        assert_eq!(result.execution_provider, "cpu");
+        assert_eq!(result.requested_device, "npu");
+        assert_eq!(result.fallback_reason, "no npu driver");
     }
 }
 

--- a/gaze/src/liveness.rs
+++ b/gaze/src/liveness.rs
@@ -1,7 +1,12 @@
 use image::RgbImage;
 use image::imageops::{FilterType, crop_imm, resize};
 use ndarray::Array4;
-use ort::{session::Session, session::builder::GraphOptimizationLevel, value::TensorRef};
+use ort::{session::Session, value::TensorRef};
+
+use gaze_core::{
+    config::InferenceConfig,
+    inference::{InferenceRuntime, create_session},
+};
 
 const INPUT_SIZE: u32 = 80;
 const CROP_SCALE: f32 = 2.7;
@@ -10,16 +15,23 @@ const SUSTAINED_SCORE_RATIO: f32 = 0.85;
 
 pub struct LivenessDetector {
     session: Session,
+    inference_runtime: InferenceRuntime,
 }
 
 impl LivenessDetector {
-    pub fn new(model_path: &str) -> anyhow::Result<Self> {
-        let session = Session::builder()
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .with_optimization_level(GraphOptimizationLevel::Level3)
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .commit_from_file(model_path)?;
-        Ok(Self { session })
+    pub fn new_with_inference(
+        model_path: &str,
+        inference: &InferenceConfig,
+    ) -> anyhow::Result<Self> {
+        let (session, inference_runtime) = create_session(model_path, inference)?;
+        Ok(Self {
+            session,
+            inference_runtime,
+        })
+    }
+
+    pub fn inference_runtime(&self) -> &InferenceRuntime {
+        &self.inference_runtime
     }
 
     // MiniFASNet expects BGR in raw 0-255 (upstream's ToTensor skips /255); RGB breaks scoring.

--- a/gaze/src/main.rs
+++ b/gaze/src/main.rs
@@ -81,21 +81,38 @@ async fn main() -> anyhow::Result<()> {
         threshold = security.threshold(),
         "Loaded security config"
     );
+    info!(
+        execution_provider = config.inference.execution_provider,
+        device = config.inference.device,
+        "Loaded inference config"
+    );
 
     let (det_path, rec_path) =
         models::ensure_models(MODELS_DIR, security.detector(), security.recognizer())?;
 
-    let detector = gaze_core::detect::FaceDetector::new(det_path.to_str().unwrap())
-        .expect("Failed to load detection model");
+    let detector = gaze_core::detect::FaceDetector::new_with_inference(
+        det_path.to_str().unwrap(),
+        &config.inference,
+    )
+    .expect("Failed to load detection model");
 
-    let recognizer_rgb = recognize::FaceRecognizer::new(rec_path.to_str().unwrap())
-        .expect("Failed to load recognition model");
-    let recognizer_ir = recognize::FaceRecognizer::new(rec_path.to_str().unwrap())
-        .expect("Failed to load recognition model");
+    let recognizer_rgb = recognize::FaceRecognizer::new_with_inference(
+        rec_path.to_str().unwrap(),
+        &config.inference,
+    )
+    .expect("Failed to load recognition model");
+    let recognizer_ir = recognize::FaceRecognizer::new_with_inference(
+        rec_path.to_str().unwrap(),
+        &config.inference,
+    )
+    .expect("Failed to load recognition model");
 
     let liveness_detector = if config.liveness.enabled {
         let path = models::ensure_liveness_model(MODELS_DIR)?;
-        Some(liveness::LivenessDetector::new(path.to_str().unwrap())?)
+        Some(liveness::LivenessDetector::new_with_inference(
+            path.to_str().unwrap(),
+            &config.inference,
+        )?)
     } else {
         None
     };

--- a/gaze/src/recognize.rs
+++ b/gaze/src/recognize.rs
@@ -1,9 +1,15 @@
 use image::RgbImage;
 use ndarray::{Array1, Array4};
-use ort::{session::Session, session::builder::GraphOptimizationLevel, value::TensorRef};
+use ort::{session::Session, value::TensorRef};
+
+use gaze_core::{
+    config::InferenceConfig,
+    inference::{InferenceRuntime, create_session},
+};
 
 pub struct FaceRecognizer {
     session: Session,
+    inference_runtime: InferenceRuntime,
 }
 
 fn normalize_embedding(row: Array1<f32>) -> anyhow::Result<Array1<f32>> {
@@ -16,13 +22,19 @@ fn normalize_embedding(row: Array1<f32>) -> anyhow::Result<Array1<f32>> {
 }
 
 impl FaceRecognizer {
-    pub fn new(model_path: &str) -> anyhow::Result<Self> {
-        let session = Session::builder()
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .with_optimization_level(GraphOptimizationLevel::Level3)
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .commit_from_file(model_path)?;
-        Ok(Self { session })
+    pub fn new_with_inference(
+        model_path: &str,
+        inference: &InferenceConfig,
+    ) -> anyhow::Result<Self> {
+        let (session, inference_runtime) = create_session(model_path, inference)?;
+        Ok(Self {
+            session,
+            inference_runtime,
+        })
+    }
+
+    pub fn inference_runtime(&self) -> &InferenceRuntime {
+        &self.inference_runtime
     }
 
     fn pre_process(img: &RgbImage) -> Array4<f32> {

--- a/packaging/config/config.toml
+++ b/packaging/config/config.toml
@@ -9,6 +9,14 @@
 # Models are automatically downloaded from the official InsightFace GitHub
 # releases if not already present in the models directory.
 
+[inference]
+# "cpu" uses the normal ONNX Runtime CPU execution provider.
+# "openvino" requires a Gaze build compiled with the openvino Cargo feature
+# and keeps the ONNX models while sending supported work through OpenVINO.
+execution_provider = "cpu"
+# Valid values: "cpu", "gpu", "npu". Use "cpu" with execution_provider = "cpu".
+device = "cpu"
+
 [security]
 level = "medium"
 


### PR DESCRIPTION
## Summary

- Keep ONNX Runtime CPU inference as the default.
- Add an explicit `openvino` Cargo feature.
- Run the existing ONNX models through the ONNX Runtime OpenVINO Execution Provider.
- Support Intel CPU, GPU, and NPU devices.
- Select the OpenVINO device at runtime through `/etc/gaze/config.toml`.
- Fall back to the ONNX Runtime CPU provider if OpenVINO session creation fails.
- Add inference configuration to the CLI, GUI, and `gaze doctor`.
- Keep ONNX Runtime out of the CLI, GUI, and PAM binaries.
- Document that the same OpenVINO-enabled binary supports GPU and NPU without recompilation.
- Document NPU as the default configuration for an OpenVINO-enabled installation.

Example NPU configuration:

```toml
[inference]
execution_provider = "openvino"
device = "npu"
```

Changing `device` to `"gpu"` uses the same binary.

## Verification

- `just fmt-check`
- `just test`: 199 passed, 2 ignored
- `just test-openvino`
- `just build-rust`
- `just build-rust-openvino`
- `just lint`
- OpenVINO Clippy checks for the daemon, core, CLI, and GUI
- `gaze doctor --benchmark` using CPU, Intel GPU, and Intel NPU

## Benchmark results

Average and p95 model-call latency in milliseconds:

| Model | CPU avg/p95 | GPU avg/p95 | NPU avg/p95 |
|---|---:|---:|---:|
| Face detector | 13.5 / 16.9 | 4.0 / 9.5 | 2.8 / 3.0 |
| RGB recognizer | 52.7 / 132.7 | 5.2 / 9.5 | 3.7 / 4.0 |
| IR recognizer | 70.2 / 135.8 | 5.2 / 9.6 | 3.0 / 3.2 |
| MiniFASNet | 2.7 / 6.8 | 1.1 / 1.5 | 1.3 / 1.3 |
