### PR TITLE
feat(cli): add --silent flag to gaze auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ gaze add-face <name>         Enroll a new face
 gaze refine-face <name>      Add samples to an existing enrollment
 gaze auth                    Authenticate
 gaze auth --verbose          Authenticate with detailed metrics
+gaze auth --silent           Authenticate silently (exit code only)
 gaze list-faces              List enrolled faces
 gaze rename-face <old> <new> Rename a face
 gaze remove-face <name>      Remove a face

--- a/docs/src/guide/cli.md
+++ b/docs/src/guide/cli.md
@@ -70,9 +70,11 @@ Useful options:
 ```bash
 gaze auth -v          # show detailed authentication metrics (short form)
 gaze auth --verbose   # same
-gaze auth -s          # run silently without TUI or stdout output (short form)
+gaze auth -s          # run silently and report the result via exit code (short form)
 gaze auth --silent    # same
 ```
+
+`--verbose` and `--silent` are mutually exclusive.
 
 Result meanings:
 
@@ -80,6 +82,34 @@ Result meanings:
 - `✗ Authentication failed (XXXms)`: no face passed the current threshold or liveness check
 
 With `--verbose`, a per-face table is printed before the result showing the per-spectrum (RGB and IR) similarity score, match percentage, and pass/fail for each enrolled face.
+
+### Exit codes
+
+`gaze auth` reports its outcome through the exit status, so it can be used directly in scripts and `if` conditions:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | A face matched and the user was authenticated |
+| `1` | Authentication failed, no faces are enrolled, or the daemon could not be reached |
+| `130` | Cancelled from the terminal UI |
+
+This applies with and without `--silent`. Earlier releases exited `0` on a failed authentication, so scripts that only checked the exit status need to be re-checked.
+
+### Silent mode
+
+`gaze auth --silent` skips the terminal UI entirely and writes nothing to stdout or stderr; the exit code is the only result. Use it in PAM helpers, scripts, and other headless contexts where no TTY is attached:
+
+```bash
+if gaze auth --silent; then
+  echo "welcome back"
+fi
+```
+
+Because silent mode is non-interactive, it cannot be cancelled from the terminal UI and it does not start a polkit agent, so authenticating another user with `--user` fails instead of prompting. Silent mode has no timeout of its own — wrap it in `timeout(1)` if the caller needs a deadline:
+
+```bash
+timeout 15 gaze auth --silent
+```
 
 ## Enroll a new face profile
 

--- a/docs/src/guide/cli.md
+++ b/docs/src/guide/cli.md
@@ -70,6 +70,8 @@ Useful options:
 ```bash
 gaze auth -v          # show detailed authentication metrics (short form)
 gaze auth --verbose   # same
+gaze auth -s          # run silently without TUI or stdout output (short form)
+gaze auth --silent    # same
 ```
 
 Result meanings:

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -176,6 +176,12 @@ enum Commands {
         user: Option<String>,
         #[arg(short, long, help = "Show detailed authentication metrics")]
         verbose: bool,
+        #[arg(
+            short,
+            long,
+            help = "Run authentication silently without terminal UI or output"
+        )]
+        silent: bool,
     },
     /// Capture a new face with guided multi-angle template
     AddFace {
@@ -630,7 +636,12 @@ async fn handle_enroll(
     Ok(())
 }
 
-async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow::Result<()> {
+async fn handle_auth(
+    proxy: &GazeProxy<'_>,
+    user: &str,
+    verbose: bool,
+    silent: bool,
+) -> anyhow::Result<()> {
     let term = Term::stdout();
 
     let has_faces = match proxy.list_faces(user).await {
@@ -639,40 +650,53 @@ async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow
         Err(e) => return Err(e.into()),
     };
     if !has_faces {
-        term.write_line(&format!(
-            "{} No faces enrolled for {}. Run {} to enroll a face.",
-            style("i").cyan().bold(),
-            style(user).bold(),
-            style("gaze add-face <name>").bold()
-        ))?;
-        return Ok(());
+        if !silent {
+            term.write_line(&format!(
+                "{} No faces enrolled for {}. Run {} to enroll a face.",
+                style("i").cyan().bold(),
+                style(user).bold(),
+                style("gaze add-face <name>").bold()
+            ))?;
+        }
+        std::process::exit(1);
     }
 
     let start = std::time::Instant::now();
 
     if let Err(err) = proxy.claim(user).await {
-        term.write_line(&format!(
-            "{} Failed to claim device: {}",
-            style("✗").red().bold(),
-            dbus_error_message(&err)
-        ))?;
-        return Ok(());
+        if !silent {
+            term.write_line(&format!(
+                "{} Failed to claim device: {}",
+                style("✗").red().bold(),
+                dbus_error_message(&err)
+            ))?;
+        }
+        std::process::exit(1);
     }
 
     let mut status_stream = proxy.receive_verify_status().await?;
     let mut capture_stream = proxy.receive_face_status().await?;
-    let mut terminal = match TuiTerminal::new() {
-        Ok(terminal) => terminal,
-        Err(err) => {
-            let _ = proxy.release().await;
-            return Err(err);
+    let mut terminal = if !silent {
+        match TuiTerminal::new() {
+            Ok(terminal) => Some(terminal),
+            Err(err) => {
+                let _ = proxy.release().await;
+                return Err(err);
+            }
         }
+    } else {
+        None
     };
+
     if let Err(e) = proxy.verify_start("any").await {
-        drop(terminal);
-        term.write_line(&format!("{} Daemon error: {}", style("✗").red().bold(), e))?;
+        if let Some(t) = terminal {
+            drop(t);
+        }
+        if !silent {
+            term.write_line(&format!("{} Daemon error: {}", style("✗").red().bold(), e))?;
+        }
         let _ = proxy.release().await;
-        return Ok(());
+        std::process::exit(1);
     }
 
     let mut status_msg = format!("Scanning face for {user}...");
@@ -682,17 +706,19 @@ async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow
     let mut verify_result = None;
 
     loop {
-        terminal.draw_auth(&AuthScreen {
-            user,
-            status: &status_msg,
-            status_tone,
-            elapsed: start.elapsed(),
-            tick,
-        })?;
+        if let Some(ref mut terminal) = terminal {
+            terminal.draw_auth(&AuthScreen {
+                user,
+                status: &status_msg,
+                status_tone,
+                elapsed: start.elapsed(),
+                tick,
+            })?;
 
-        if let Some(TuiAction::Cancel) = tui::poll_action()? {
-            cancelled = true;
-            break;
+            if let Some(TuiAction::Cancel) = tui::poll_action()? {
+                cancelled = true;
+                break;
+            }
         }
 
         tokio::select! {
@@ -722,7 +748,9 @@ async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow
         }
     }
 
-    drop(terminal);
+    if let Some(t) = terminal {
+        drop(t);
+    }
 
     if cancelled {
         let _ = proxy.verify_stop().await;
@@ -730,8 +758,9 @@ async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow
         std::process::exit(130);
     }
 
+    let mut authenticated = false;
     if let Some((result, faces, rgb_status, ir_status)) = verify_result {
-        if verbose {
+        if verbose && !silent {
             println!(
                 "\n{:<20} {:>10} {:>8} {:>8} {:>10} {:>8} {:>8}",
                 style("Face").bold(),
@@ -777,44 +806,56 @@ async fn handle_auth(proxy: &GazeProxy<'_>, user: &str, verbose: bool) -> anyhow
         }
 
         if result == VerifyResult::VerifyMatch {
-            let matched = faces
-                .iter()
-                .find(|(_, _, _, rgb_p, _, _, ir_p)| *rgb_p || *ir_p)
-                .map(|(n, _, rgb_pct, rgb_p, _, ir_pct, ir_p)| {
-                    let pct = if *rgb_p && *ir_p {
-                        rgb_pct.max(*ir_pct)
-                    } else if *rgb_p {
-                        *rgb_pct
-                    } else {
-                        *ir_pct
-                    };
-                    (n.clone(), pct)
-                });
-            if let Some((face, pct)) = matched {
-                term.write_line(&format!(
-                    "{} Authenticated as: {} ({:.1}%, {}ms)",
-                    style("✓").green().bold(),
-                    style(&face).green().bold(),
-                    pct,
-                    start.elapsed().as_millis()
-                ))?;
-            } else {
-                term.write_line(&format!(
-                    "{} Authenticated as: {} ({}ms)",
-                    style("✓").green().bold(),
-                    style(user).green().bold(),
-                    start.elapsed().as_millis()
-                ))?;
+            authenticated = true;
+            if !silent {
+                let matched = faces
+                    .iter()
+                    .find(|(_, _, _, rgb_p, _, _, ir_p)| *rgb_p || *ir_p)
+                    .map(|(n, _, rgb_pct, rgb_p, _, ir_pct, ir_p)| {
+                        let pct = if *rgb_p && *ir_p {
+                            rgb_pct.max(*ir_pct)
+                        } else if *rgb_p {
+                            *rgb_pct
+                        } else {
+                            *ir_pct
+                        };
+                        (n.clone(), pct)
+                    });
+                if let Some((face, pct)) = matched {
+                    term.write_line(&format!(
+                        "{} Authenticated as: {} ({:.1}%, {}ms)",
+                        style("✓").green().bold(),
+                        style(&face).green().bold(),
+                        pct,
+                        start.elapsed().as_millis()
+                    ))?;
+                } else {
+                    term.write_line(&format!(
+                        "{} Authenticated as: {} ({}ms)",
+                        style("✓").green().bold(),
+                        style(user).green().bold(),
+                        start.elapsed().as_millis()
+                    ))?;
+                }
             }
-        } else {
+        } else if !silent {
             term.write_line(&format!(
                 "{} Authentication failed ({}ms)",
                 style("✗").red().bold(),
                 start.elapsed().as_millis()
             ))?;
         }
+    } else if !silent {
+        term.write_line(&format!(
+            "{} Authentication failed ({}ms)",
+            style("✗").red().bold(),
+            start.elapsed().as_millis()
+        ))?;
     }
     let _ = proxy.release().await;
+    if !authenticated {
+        std::process::exit(1);
+    }
     Ok(())
 }
 
@@ -1414,8 +1455,18 @@ async fn run() -> anyhow::Result<()> {
     let proxy = connect_gaze().await?;
 
     match cli.command {
-        Commands::Auth { user, verbose } => {
-            handle_auth(&proxy, &user.unwrap_or_else(get_current_user), verbose).await?;
+        Commands::Auth {
+            user,
+            verbose,
+            silent,
+        } => {
+            handle_auth(
+                &proxy,
+                &user.unwrap_or_else(get_current_user),
+                verbose,
+                silent,
+            )
+            .await?;
         }
         Commands::AddFace { user, face } => {
             handle_enroll(&proxy, &user.unwrap_or_else(get_current_user), &face, false).await?;
@@ -1575,8 +1626,19 @@ mod tests {
             cli.command,
             Commands::Auth {
                 user: Some(ref user),
-                verbose: true
+                verbose: true,
+                silent: false,
             } if user == "alice"
+        ));
+
+        let cli = Cli::try_parse_from(["gaze", "auth", "-s", "-u", "bob"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Auth {
+                user: Some(ref user),
+                verbose: false,
+                silent: true,
+            } if user == "bob"
         ));
 
         let cli = Cli::try_parse_from(["gaze", "uninstall", "--yes", "--keep-data", "--dry-run"])

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -174,12 +174,17 @@ enum Commands {
     Auth {
         #[arg(short, long)]
         user: Option<String>,
-        #[arg(short, long, help = "Show detailed authentication metrics")]
+        #[arg(
+            short,
+            long,
+            conflicts_with = "silent",
+            help = "Show detailed authentication metrics"
+        )]
         verbose: bool,
         #[arg(
             short,
             long,
-            help = "Run authentication silently without terminal UI or output"
+            help = "Suppress the terminal UI and all output; report the result via exit code"
         )]
         silent: bool,
     },
@@ -689,9 +694,7 @@ async fn handle_auth(
     };
 
     if let Err(e) = proxy.verify_start("any").await {
-        if let Some(t) = terminal {
-            drop(t);
-        }
+        drop(terminal);
         if !silent {
             term.write_line(&format!("{} Daemon error: {}", style("✗").red().bold(), e))?;
         }
@@ -723,17 +726,15 @@ async fn handle_auth(
 
         tokio::select! {
             signal = status_stream.next() => {
-                if let Some(signal) = signal
-                    && let Ok(args) = signal.args()
-                {
+                let Some(signal) = signal else { break };
+                if let Ok(args) = signal.args() {
                     verify_result = Some((*args.result(), args.faces().clone(), *args.rgb_status(), *args.ir_status()));
                     break;
                 }
             }
             signal = capture_stream.next() => {
-                if let Some(signal) = signal
-                    && let Ok(args) = signal.args()
-                {
+                let Some(signal) = signal else { break };
+                if let Ok(args) = signal.args() {
                     let status = *args.status();
                     status_tone = capture_tone(status);
                     status_msg = match status {
@@ -748,9 +749,7 @@ async fn handle_auth(
         }
     }
 
-    if let Some(t) = terminal {
-        drop(t);
-    }
+    drop(terminal);
 
     if cancelled {
         let _ = proxy.verify_stop().await;
@@ -760,7 +759,7 @@ async fn handle_auth(
 
     let mut authenticated = false;
     if let Some((result, faces, rgb_status, ir_status)) = verify_result {
-        if verbose && !silent {
+        if verbose {
             println!(
                 "\n{:<20} {:>10} {:>8} {:>8} {:>10} {:>8} {:>8}",
                 style("Face").bold(),
@@ -838,20 +837,17 @@ async fn handle_auth(
                     ))?;
                 }
             }
-        } else if !silent {
-            term.write_line(&format!(
-                "{} Authentication failed ({}ms)",
-                style("✗").red().bold(),
-                start.elapsed().as_millis()
-            ))?;
         }
-    } else if !silent {
+    }
+
+    if !authenticated && !silent {
         term.write_line(&format!(
             "{} Authentication failed ({}ms)",
             style("✗").red().bold(),
             start.elapsed().as_millis()
         ))?;
     }
+
     let _ = proxy.release().await;
     if !authenticated {
         std::process::exit(1);
@@ -1433,7 +1429,10 @@ async fn run() -> anyhow::Result<()> {
         reexec_as_root(name)?;
     }
 
-    let _polkit_agent = command_may_be_challenged(&cli.command).then(polkit::PolkitAgent::spawn);
+    let silent_auth = matches!(cli.command, Commands::Auth { silent: true, .. });
+
+    let _polkit_agent = (command_may_be_challenged(&cli.command) && !silent_auth)
+        .then(polkit::PolkitAgent::spawn);
 
     match &cli.command {
         Commands::Uninstall {
@@ -1452,7 +1451,11 @@ async fn run() -> anyhow::Result<()> {
         _ => {}
     }
 
-    let proxy = connect_gaze().await?;
+    let proxy = match connect_gaze().await {
+        Ok(proxy) => proxy,
+        Err(_) if silent_auth => std::process::exit(1),
+        Err(e) => return Err(e.into()),
+    };
 
     match cli.command {
         Commands::Auth {
@@ -1460,13 +1463,17 @@ async fn run() -> anyhow::Result<()> {
             verbose,
             silent,
         } => {
-            handle_auth(
+            let result = handle_auth(
                 &proxy,
                 &user.unwrap_or_else(get_current_user),
                 verbose,
                 silent,
             )
-            .await?;
+            .await;
+            if silent && result.is_err() {
+                std::process::exit(1);
+            }
+            result?;
         }
         Commands::AddFace { user, face } => {
             handle_enroll(&proxy, &user.unwrap_or_else(get_current_user), &face, false).await?;
@@ -1640,6 +1647,18 @@ mod tests {
                 silent: true,
             } if user == "bob"
         ));
+
+        let cli = Cli::try_parse_from(["gaze", "auth", "--silent"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Auth {
+                user: None,
+                verbose: false,
+                silent: true,
+            }
+        ));
+
+        assert!(Cli::try_parse_from(["gaze", "auth", "--verbose", "--silent"]).is_err());
 
         let cli = Cli::try_parse_from(["gaze", "uninstall", "--yes", "--keep-data", "--dry-run"])
             .unwrap();

--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -1431,8 +1431,8 @@ async fn run() -> anyhow::Result<()> {
 
     let silent_auth = matches!(cli.command, Commands::Auth { silent: true, .. });
 
-    let _polkit_agent = (command_may_be_challenged(&cli.command) && !silent_auth)
-        .then(polkit::PolkitAgent::spawn);
+    let _polkit_agent =
+        (command_may_be_challenged(&cli.command) && !silent_auth).then(polkit::PolkitAgent::spawn);
 
     match &cli.command {
         Commands::Uninstall {


### PR DESCRIPTION
### What & Why

Currently, `gaze auth` launches a terminal UI (TUI) assuming an interactive terminal session. This makes it fail or print unwanted terminal interface output when used in scripts, headless environments, or background automation where no TTY is attached.

This PR adds a `--silent` (`-s`) flag to `gaze auth`. When enabled:
- Bypasses the TUI setup so it runs smoothly in non-interactive / headless environments.
- Suppresses standard terminal output while returning standard exit codes (`0` on successful authentication match, `1` on failure/error).

### Testing
- Added unit tests for `-s` / `--silent` CLI argument parsing.
- Verified test suite and linter via `cargo test` and `just lint`.