### PR TITLE
fix(camera): support single-node RGB/IR cameras

### DIFF
--- a/gaze-cli/src/main.rs
+++ b/gaze-cli/src/main.rs
@@ -726,6 +726,7 @@ async fn handle_auth(
 
     let mut status_stream = proxy.receive_verify_status().await?;
     let mut capture_stream = proxy.receive_face_status().await?;
+    let mut diagnostic_stream = proxy.receive_verify_diagnostic().await?;
     let mut terminal = if !silent {
         match TuiTerminal::new() {
             Ok(terminal) => Some(terminal),
@@ -752,6 +753,7 @@ async fn handle_auth(
     let mut tick = 0_u64;
     let mut cancelled = false;
     let mut verify_result = None;
+    let mut diagnostics = Vec::new();
 
     loop {
         if let Some(ref mut terminal) = terminal {
@@ -788,6 +790,12 @@ async fn handle_auth(
                     };
                 }
             }
+            signal = diagnostic_stream.next(), if verbose => {
+                let Some(signal) = signal else { break };
+                if let Ok(args) = signal.args() {
+                    diagnostics.push(args.message().to_string());
+                }
+            }
             _ = tokio::time::sleep(Duration::from_millis(80)) => {
                 tick = tick.wrapping_add(1);
             }
@@ -795,6 +803,16 @@ async fn handle_auth(
     }
 
     drop(terminal);
+
+    if verbose {
+        while let Ok(Some(signal)) =
+            tokio::time::timeout(Duration::from_millis(20), diagnostic_stream.next()).await
+        {
+            if let Ok(args) = signal.args() {
+                diagnostics.push(args.message().to_string());
+            }
+        }
+    }
 
     if cancelled {
         let _ = proxy.verify_stop().await;
@@ -805,6 +823,12 @@ async fn handle_auth(
     let mut authenticated = false;
     if let Some((result, faces, rgb_status, ir_status)) = verify_result {
         if verbose {
+            for message in &diagnostics {
+                println!("{message}");
+            }
+            if !diagnostics.is_empty() {
+                println!();
+            }
             println!(
                 "\n{:<20} {:>10} {:>8} {:>8} {:>10} {:>8} {:>8}",
                 style("Face").bold(),

--- a/gaze-core/src/camera.rs
+++ b/gaze-core/src/camera.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{info, warn};
 
 use crate::config::{CameraConfig, DEFAULT_RGB_CAMERA};
-use crate::ir::devices::usb_ids_of;
+use crate::ir::devices::{find_device, usb_ids_of};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CameraKind {
@@ -200,11 +200,24 @@ fn select_usb_node(
     pid: u16,
     want_color: bool,
 ) -> Option<String> {
-    nodes
-        .iter()
-        .filter(|n| n.vid == vid && n.pid == pid && n.is_color == want_color)
+    let matching_nodes = || nodes.iter().filter(|n| n.vid == vid && n.pid == pid);
+
+    matching_nodes()
+        .filter(|n| n.is_color == want_color)
         .min_by_key(|n| video_node_index(&n.node).unwrap_or(u32::MAX))
         .map(|n| n.node.clone())
+        .or_else(|| {
+            // Some Windows Hello cameras expose RGB and IR through one UVC
+            // capture node. Their emitter profile switches that node into IR
+            // mode, so there is no separately advertised mono node to select.
+            if want_color || find_device(vid, pid).is_none() {
+                return None;
+            }
+
+            matching_nodes()
+                .min_by_key(|n| video_node_index(&n.node).unwrap_or(u32::MAX))
+                .map(|n| n.node.clone())
+        })
 }
 
 fn video_node_index(node: &str) -> Option<u32> {
@@ -345,8 +358,8 @@ impl Camera {
 
     fn open_kind(camera_source: &str, want_color: bool) -> anyhow::Result<Self> {
         gstreamer::init()?;
-        let src_element = match classify_source(camera_source, want_color)? {
-            SourceElement::Element(element) => element,
+        let (src_element, force_ir_yuy2) = match classify_source(camera_source, want_color)? {
+            SourceElement::Element(element) => (element, false),
             SourceElement::ResolveUsb {
                 vid,
                 pid,
@@ -358,11 +371,14 @@ impl Camera {
                         if want_color { "color" } else { "IR" }
                     )
                 })?;
-                format!("v4l2src device={node}")
+                (
+                    format!("v4l2src device={node}"),
+                    !want_color && vid == 0x0bda && matches!(pid, 0x5767 | 0x58c2),
+                )
             }
         };
 
-        match Self::open_source_element(&src_element, camera_source) {
+        match Self::open_source_element(&src_element, camera_source, force_ir_yuy2) {
             Ok(camera) => Ok(camera),
             Err(err) if src_element == "pipewiresrc" => {
                 warn!("Opening the PipeWire camera failed ({err:#}); trying a direct V4L2 device");
@@ -372,16 +388,18 @@ impl Camera {
                     )
                 })?;
                 info!("Falling back to V4L2 camera node {node}");
-                Self::open_source_element(&format!("v4l2src device={node}"), camera_source)
+                Self::open_source_element(&format!("v4l2src device={node}"), camera_source, false)
             }
             Err(err) => Err(err),
         }
     }
 
-    fn open_source_element(src_element: &str, camera_source: &str) -> anyhow::Result<Self> {
-        let pipeline_str = format!(
-            "{src_element} ! video/x-raw,pixel-aspect-ratio=1/1; image/jpeg ! decodebin ! videoconvert ! videoscale ! appsink name=gaze_sink"
-        );
+    fn open_source_element(
+        src_element: &str,
+        camera_source: &str,
+        force_ir_yuy2: bool,
+    ) -> anyhow::Result<Self> {
+        let pipeline_str = camera_pipeline(src_element, force_ir_yuy2);
         info!("Attempting to open GStreamer camera: {}", pipeline_str);
 
         let pipeline = gstreamer::parse::launch(&pipeline_str)
@@ -517,6 +535,20 @@ impl Camera {
         }
 
         None
+    }
+}
+
+fn camera_pipeline(src_element: &str, force_ir_yuy2: bool) -> String {
+    if force_ir_yuy2 {
+        // Dell/Realtek single-node RGB/IR modules silently remain in RGB mode
+        // unless the stream is negotiated as uncompressed 640x480 YUY2.
+        format!(
+            "{src_element} ! video/x-raw,format=YUY2,width=640,height=480,pixel-aspect-ratio=1/1 ! videoconvert ! videoscale ! appsink name=gaze_sink"
+        )
+    } else {
+        format!(
+            "{src_element} ! video/x-raw,pixel-aspect-ratio=1/1; image/jpeg ! decodebin ! videoconvert ! videoscale ! appsink name=gaze_sink"
+        )
     }
 }
 
@@ -662,6 +694,16 @@ fn is_mono_format(format: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn realtek_ir_pipeline_forces_required_uncompressed_mode() {
+        let pipeline = camera_pipeline("v4l2src device=/dev/video0", true);
+        assert!(pipeline.contains("video/x-raw,format=YUY2,width=640,height=480"));
+        assert!(!pipeline.contains("image/jpeg"));
+
+        let rgb_pipeline = camera_pipeline("v4l2src device=/dev/video0", false);
+        assert!(rgb_pipeline.contains("image/jpeg"));
+    }
 
     #[test]
     fn resolve_source_uses_rgb_when_no_ir_configured() {
@@ -881,6 +923,21 @@ mod tests {
         assert_eq!(
             select_usb_node(&nodes, 0x046d, 0x085e, true),
             Some("/dev/video2".to_string())
+        );
+    }
+
+    #[test]
+    fn select_usb_node_reuses_single_node_for_known_ir_profile() {
+        let nodes = vec![VideoNodeInfo {
+            node: "/dev/video6".to_string(),
+            vid: 0x0bda,
+            pid: 0x58c2,
+            is_color: true,
+        }];
+
+        assert_eq!(
+            select_usb_node(&nodes, 0x0bda, 0x58c2, false),
+            Some("/dev/video6".to_string())
         );
     }
 

--- a/gaze-core/src/dbus.rs
+++ b/gaze-core/src/dbus.rs
@@ -343,6 +343,9 @@ pub trait Gaze {
     ) -> zbus::Result<()>;
 
     #[zbus(signal)]
+    fn verify_diagnostic(&self, message: &str) -> zbus::Result<()>;
+
+    #[zbus(signal)]
     fn enroll_status(
         &self,
         face_name: &str,

--- a/gaze-core/src/face.rs
+++ b/gaze-core/src/face.rs
@@ -194,6 +194,15 @@ impl IrDarkFrameGate {
 
     pub fn classify(&mut self, frame: &Mat) -> IrFrameKind {
         let luma = frame_mean_luma(frame).unwrap_or(0);
+        self.classify_luma(luma)
+    }
+
+    pub fn classify_with_luma(&mut self, frame: &Mat) -> (IrFrameKind, u8) {
+        let luma = frame_mean_luma(frame).unwrap_or(0);
+        (self.classify_luma(luma), luma)
+    }
+
+    fn classify_luma(&mut self, luma: u8) -> IrFrameKind {
         if luma >= self.threshold {
             self.consecutive_dark = 0;
             return IrFrameKind::Lit;

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -76,21 +76,25 @@ pub struct FaceData {
 
 struct EmitterGuard {
     led: Option<IrLed>,
+    activation_message: Option<String>,
 }
 
 impl EmitterGuard {
     fn engage(kind: &CameraKind, enabled: bool) -> Self {
+        let mut activation_message = None;
         let led = match kind {
             CameraKind::Ir { node, .. } if enabled => match IrLed::for_path(node) {
                 Some(led) => {
                     if let Err(e) = led.set(true) {
                         warn!("IR emitter activate failed: {e}");
                     } else {
-                        info!(
+                        let message = format!(
                             "IR emitter enabled via {} on {}",
                             led.device_name(),
                             led.node()
                         );
+                        info!("{message}");
+                        activation_message = Some(message);
                     }
                     Some(led)
                 }
@@ -101,7 +105,14 @@ impl EmitterGuard {
             },
             _ => None,
         };
-        Self { led }
+        Self {
+            led,
+            activation_message,
+        }
+    }
+
+    fn activation_message(&self) -> Option<&str> {
+        self.activation_message.as_deref()
     }
 }
 
@@ -1355,6 +1366,7 @@ pub async fn watch_session_locks(conn: zbus::Connection, lock_epochs: LockEpochs
 
 enum VerifyMsg {
     PhaseStarted(Spectrum),
+    Diagnostic(String),
     Status(Spectrum, CaptureStatus, Option<ndarray::Array1<f32>>),
     Success(Spectrum, ndarray::Array1<f32>),
     Error(String),
@@ -2839,6 +2851,9 @@ impl AuthDaemon {
     ) -> zbus::Result<()>;
 
     #[zbus(signal)]
+    async fn verify_diagnostic(ctxt: &SignalEmitter<'_>, message: &str) -> zbus::Result<()>;
+
+    #[zbus(signal)]
     async fn face_status(ctxt: &SignalEmitter<'_>, status: CaptureStatus) -> zbus::Result<()>;
 
     #[zbus(signal)]
@@ -3178,10 +3193,13 @@ impl AuthDaemon {
 
                     let _ = tx.blocking_send(VerifyMsg::PhaseStarted(Spectrum::Ir));
 
-                    let _emitter = EmitterGuard::engage(
+                    let emitter = EmitterGuard::engage(
                         &CameraKind::Ir { source: ir_device_clone.clone(), node: ir_node_clone.clone() },
                         emitter_enabled
                     );
+                    if let Some(message) = emitter.activation_message() {
+                        let _ = tx.blocking_send(VerifyMsg::Diagnostic(message.to_owned()));
+                    }
 
                     let mut cam = match Camera::open_ir(&ir_device_clone) {
                         Ok(c) => c,
@@ -3207,10 +3225,12 @@ impl AuthDaemon {
                         match frame_kind {
                             IrFrameKind::Lit => {
                                 if !logged_lit_luma {
-                                    info!(
+                                    let message = format!(
                                         "IR stream produced a lit frame: mean_luma={luma}, threshold={}",
                                         config_clone.cameras.dark_luma_threshold
                                     );
+                                    info!("{message}");
+                                    let _ = tx.try_send(VerifyMsg::Diagnostic(message));
                                     logged_lit_luma = true;
                                 }
                             }
@@ -3375,6 +3395,9 @@ impl AuthDaemon {
                                 dark_since = None;
                             }
                             VerifyMsg::PhaseStarted(_) => {}
+                            VerifyMsg::Diagnostic(message) => {
+                                let _ = Self::verify_diagnostic(&ctxt, &message).await;
+                            }
                             VerifyMsg::Status(spectrum, status, embed_opt) => {
                                 let has_face = embed_opt.is_some();
                                 match spectrum {

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -85,6 +85,12 @@ impl EmitterGuard {
                 Some(led) => {
                     if let Err(e) = led.set(true) {
                         warn!("IR emitter activate failed: {e}");
+                    } else {
+                        info!(
+                            "IR emitter enabled via {} on {}",
+                            led.device_name(),
+                            led.node()
+                        );
                     }
                     Some(led)
                 }
@@ -571,7 +577,7 @@ impl AuthDaemon {
 mod tests {
     use super::{
         AuthDaemon, ClaimState, and_policy_unsatisfiable, auth_streams, claim_has_epoch,
-        eyes_from_kpss, hybrid_auth_passed, pipewire_runtime_update,
+        eyes_from_kpss, hybrid_auth_passed, pipewire_runtime_update, should_yield_rgb_to_ir,
     };
     use gaze_core::config::AuthSurface;
     use gaze_core::dbus::{ActiveSession, CaptureStatus};
@@ -1155,6 +1161,25 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_fallback_yields_dark_rgb_to_ir_immediately() {
+        for policy in ["fallback_on_dark", "default", ""] {
+            assert!(should_yield_rgb_to_ir(policy, true, CaptureStatus::TooDark));
+        }
+        assert!(!should_yield_rgb_to_ir(
+            "fallback_on_dark",
+            false,
+            CaptureStatus::TooDark
+        ));
+        assert!(!should_yield_rgb_to_ir(
+            "fallback_on_dark",
+            true,
+            CaptureStatus::NoFace
+        ));
+        assert!(!should_yield_rgb_to_ir("or", true, CaptureStatus::TooDark));
+        assert!(!should_yield_rgb_to_ir("and", true, CaptureStatus::TooDark));
+    }
+
+    #[test]
     fn single_spectrum_authentication_ignores_the_other_result() {
         assert!(hybrid_auth_passed(
             "and",
@@ -1329,9 +1354,14 @@ pub async fn watch_session_locks(conn: zbus::Connection, lock_epochs: LockEpochs
 }
 
 enum VerifyMsg {
+    PhaseStarted(Spectrum),
     Status(Spectrum, CaptureStatus, Option<ndarray::Array1<f32>>),
     Success(Spectrum, ndarray::Array1<f32>),
     Error(String),
+}
+
+fn should_yield_rgb_to_ir(policy: &str, run_ir: bool, status: CaptureStatus) -> bool {
+    run_ir && !matches!(policy, "or" | "and") && matches!(status, CaptureStatus::TooDark)
 }
 
 fn hybrid_auth_passed(
@@ -2160,6 +2190,8 @@ impl AuthDaemon {
                                 continue;
                             }
 
+                            // Realtek switches mode before the exact IR stream format is
+                            // negotiated; changing format afterwards silently restores RGB.
                             let _emitter = EmitterGuard::engage(
                                 &CameraKind::Ir { source: ir_device_clone.clone(), node: ir_node_clone.clone() },
                                 emitter_enabled
@@ -2978,6 +3010,7 @@ impl AuthDaemon {
                 let liveness_threshold = liveness_cfg.effective_threshold();
                 let rgb_device_clone = rgb_device.clone();
                 let rgb_phase_done_clone = rgb_phase_done.clone();
+                let hybrid_policy_clone = hybrid_policy.clone();
 
                 rgb_thread = Some(std::thread::spawn(move || {
                     // Set once the RGB camera is released, on every exit path (incl. panic),
@@ -3032,6 +3065,11 @@ impl AuthDaemon {
 
                         let latest_embed = embed_opt.as_ref().map(|d| d.embedding.clone());
                         let _ = tx.try_send(VerifyMsg::Status(Spectrum::Rgb, status, latest_embed));
+
+                        if should_yield_rgb_to_ir(&hybrid_policy_clone, run_ir, status) {
+                            yielded_to_ir = true;
+                            break;
+                        }
 
                         if status == CaptureStatus::Usable && let Some(data) = embed_opt {
                             let threshold = *threshold_arc.blocking_lock();
@@ -3138,6 +3176,8 @@ impl AuthDaemon {
                         }
                     }
 
+                    let _ = tx.blocking_send(VerifyMsg::PhaseStarted(Spectrum::Ir));
+
                     let _emitter = EmitterGuard::engage(
                         &CameraKind::Ir { source: ir_device_clone.clone(), node: ir_node_clone.clone() },
                         emitter_enabled
@@ -3154,6 +3194,8 @@ impl AuthDaemon {
 
                     let mut checker = FaceChecker::new(detector_arc, &config_clone, Spectrum::Ir, false);
                     let mut dark_gate = IrDarkFrameGate::new(config_clone.cameras.dark_luma_threshold);
+                    let mut logged_lit_luma = false;
+                    let mut logged_dark_luma = false;
                     let mut landmark_seq: Vec<[(f32, f32); 5]> = Vec::new();
 
                     while let Some(frame) = cam.next_interruptible(&stop_clone) {
@@ -3161,10 +3203,26 @@ impl AuthDaemon {
                             break;
                         }
 
-                        match dark_gate.classify(&frame) {
-                            IrFrameKind::Lit => {}
+                        let (frame_kind, luma) = dark_gate.classify_with_luma(&frame);
+                        match frame_kind {
+                            IrFrameKind::Lit => {
+                                if !logged_lit_luma {
+                                    info!(
+                                        "IR stream produced a lit frame: mean_luma={luma}, threshold={}",
+                                        config_clone.cameras.dark_luma_threshold
+                                    );
+                                    logged_lit_luma = true;
+                                }
+                            }
                             IrFrameKind::StrobeDark => continue,
                             IrFrameKind::EmitterDark => {
+                                if !logged_dark_luma {
+                                    info!(
+                                        "IR stream remains dark after emitter warmup: mean_luma={luma}, threshold={}",
+                                        config_clone.cameras.dark_luma_threshold
+                                    );
+                                    logged_dark_luma = true;
+                                }
                                 let _ = tx.try_send(VerifyMsg::Status(Spectrum::Ir, CaptureStatus::TooDark, None));
                                 continue;
                             }
@@ -3310,6 +3368,13 @@ impl AuthDaemon {
                             break;
                         };
                         match msg {
+                            VerifyMsg::PhaseStarted(Spectrum::Ir) => {
+                                // RGB and IR run serially on single-function cameras. Give
+                                // IR a fresh no-face window after RGB releases the device.
+                                last_face_at = Instant::now();
+                                dark_since = None;
+                            }
+                            VerifyMsg::PhaseStarted(_) => {}
                             VerifyMsg::Status(spectrum, status, embed_opt) => {
                                 let has_face = embed_opt.is_some();
                                 match spectrum {


### PR DESCRIPTION
## Summary

Adds support for single-node RGB/IR UVC cameras, including the Realtek 0bda:58c2 module.

- Reuse a known emitter-profile camera's capture node when no separate mono node is exposed.
- Force the Realtek IR stream to uncompressed 640x480 YUY2, which its firmware requires for IR mode.
- Yield a dark RGB phase directly to IR for hybrid fallback authentication and reset the IR timeout window.
- Log emitter activation and IR luma to make hardware failures diagnosable.

## Root cause

The affected camera exposes RGB and IR behind one capture node. The previous node resolver required a separate mono node, and the default stream negotiation could select MJPEG, which causes this Realtek firmware to ignore the IR-mode command.

## Validation

- `cargo test -p gaze-core -p gaze`
- NixOS system closure build with the local Gaze checkout
