### PR TITLE
fix(daemon): release the claim when its sender vanishes during watcher setup

### DIFF
--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -63,13 +63,14 @@ fn claim_has_epoch(state: &Option<ClaimState>, epoch: u64) -> bool {
     matches!(state, Some(claim) if claim.epoch == epoch)
 }
 
-/// Drop the claim identified by `epoch` and cancel whatever task it owns.
-///
-/// Matching on the epoch rather than the sender name keeps a late release from
-/// stealing a newer claim: a connection that claims, releases, and claims again reuses
-/// its unique name but never its epoch.
-///
-/// Returns `true` when this call is what dropped the claim.
+/// Whether a NameOwnerChanged signal says `watched` lost its owner. A `new_owner`
+/// means the name was acquired or handed on, not that the client went away.
+fn is_vanish_of(name: &str, new_owner: Option<&str>, watched: &str) -> bool {
+    name == watched && new_owner.is_none()
+}
+
+/// Drop the claim identified by `epoch`, cancel its task, and report whether this call
+/// is what dropped it. Epochs are unique per claim; unique names are not.
 async fn release_claim_epoch(
     claim_state: &Arc<Mutex<Option<ClaimState>>>,
     active_cancel: &Arc<Mutex<Option<oneshot::Sender<()>>>>,
@@ -613,12 +614,13 @@ impl AuthDaemon {
 mod tests {
     use super::{
         AuthDaemon, ClaimState, and_policy_unsatisfiable, auth_streams, claim_has_epoch,
-        eyes_from_kpss, hybrid_auth_passed, pipewire_runtime_update, release_claim_epoch,
-        should_yield_rgb_to_ir,
+        eyes_from_kpss, hybrid_auth_passed, is_vanish_of, pipewire_runtime_update,
+        release_claim_epoch, should_yield_rgb_to_ir,
     };
     use gaze_core::config::AuthSurface;
     use gaze_core::dbus::{ActiveSession, CaptureStatus};
     use std::sync::Arc;
+    use tokio::sync::oneshot::error::TryRecvError;
     use tokio::sync::{Mutex, oneshot};
 
     fn session(class: &str) -> ActiveSession {
@@ -727,9 +729,7 @@ mod tests {
         })))
     }
 
-    // The vanish watcher and the claim timeout both release through this path. A
-    // sender that disappears before the watcher subscribes is released by the
-    // post-subscribe owner re-check, which calls exactly this.
+    // The vanish watcher, the owner re-check, and the claim timeout all release here.
     #[tokio::test]
     async fn release_clears_and_cancels() {
         let claim_state = claim_at(7);
@@ -738,14 +738,10 @@ mod tests {
 
         assert!(release_claim_epoch(&claim_state, &active_cancel, 7).await);
         assert!(claim_state.lock().await.is_none());
-        // try_recv, not await: the send happens before the call returns, and awaiting a
-        // receiver whose sender is still parked in `active_cancel` would hang instead of
-        // failing if the cancel were ever dropped.
         assert!(rx.try_recv().is_ok(), "the active task must be cancelled");
     }
 
-    // A watcher spawned for an earlier claim must not release the claim that replaced
-    // it, otherwise a slow vanish signal would revoke a live authentication.
+    // A watcher spawned for an earlier claim must not revoke the one that replaced it.
     #[tokio::test]
     async fn stale_epoch_spares_newer_claim() {
         let claim_state = claim_at(8);
@@ -754,8 +750,10 @@ mod tests {
 
         assert!(!release_claim_epoch(&claim_state, &active_cancel, 7).await);
         assert!(claim_has_epoch(&*claim_state.lock().await, 8));
+        // Empty, not just Err: a dropped sender also reports Err but leaves the newer
+        // claim's task uncancellable.
         assert!(
-            rx.try_recv().is_err(),
+            matches!(rx.try_recv(), Err(TryRecvError::Empty)),
             "the newer claim's task must not be cancelled"
         );
     }
@@ -770,6 +768,71 @@ mod tests {
         assert!(release_claim_epoch(&claim_state, &active_cancel, 9).await);
         assert!(!release_claim_epoch(&claim_state, &active_cancel, 9).await);
         assert!(claim_state.lock().await.is_none());
+    }
+
+    // A claim held with no verification running still has to clear.
+    #[tokio::test]
+    async fn release_without_an_active_task_still_clears() {
+        let claim_state = claim_at(3);
+        let active_cancel = Arc::new(Mutex::new(None));
+
+        assert!(release_claim_epoch(&claim_state, &active_cancel, 3).await);
+        assert!(claim_state.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn release_on_an_unclaimed_daemon_is_a_noop() {
+        let claim_state = Arc::new(Mutex::new(None));
+        let (tx, mut rx) = oneshot::channel();
+        let active_cancel = Arc::new(Mutex::new(Some(tx)));
+
+        assert!(!release_claim_epoch(&claim_state, &active_cancel, 1).await);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    // The case the epoch guard exists for: one connection claims, releases, and claims
+    // again, so the same unique name backs two different claims.
+    #[tokio::test]
+    async fn same_sender_reclaiming_is_not_released_by_the_old_epoch() {
+        let claim_state = claim_at(11);
+        let active_cancel = Arc::new(Mutex::new(None));
+
+        assert!(release_claim_epoch(&claim_state, &active_cancel, 11).await);
+        *claim_state.lock().await = Some(ClaimState {
+            username: "alice".to_string(),
+            sender: ":1.42".to_string(),
+            epoch: 12,
+        });
+
+        assert!(!release_claim_epoch(&claim_state, &active_cancel, 11).await);
+        assert!(claim_has_epoch(&*claim_state.lock().await, 12));
+    }
+
+    // The re-check and the vanish signal race by design; exactly one may win.
+    #[tokio::test]
+    async fn concurrent_releases_elect_a_single_winner() {
+        let claim_state = claim_at(4);
+        let (tx, mut rx) = oneshot::channel();
+        let active_cancel = Arc::new(Mutex::new(Some(tx)));
+
+        let (a, b) = tokio::join!(
+            release_claim_epoch(&claim_state, &active_cancel, 4),
+            release_claim_epoch(&claim_state, &active_cancel, 4)
+        );
+
+        assert!(a ^ b, "exactly one caller must report the release");
+        assert!(claim_state.lock().await.is_none());
+        assert!(rx.try_recv().is_ok(), "the active task must be cancelled");
+    }
+
+    #[test]
+    fn vanish_needs_the_watched_name_and_no_new_owner() {
+        assert!(is_vanish_of(":1.42", None, ":1.42"));
+        // An acquisition or hand-off is not a disappearance.
+        assert!(!is_vanish_of(":1.42", Some(":1.42"), ":1.42"));
+        assert!(!is_vanish_of(":1.99", None, ":1.42"));
+        // Prefix collision: ":1.4" vanishing must not release ":1.42".
+        assert!(!is_vanish_of(":1.4", None, ":1.42"));
     }
 
     #[test]
@@ -1910,24 +1973,37 @@ impl AuthDaemon {
         let sender_for_watcher = sender.clone();
 
         self.rt_handle.spawn(async move {
-            let Ok(dbus) = fdo::DBusProxy::new(&conn).await else {
-                return;
+            let dbus = match fdo::DBusProxy::new(&conn).await {
+                Ok(dbus) => dbus,
+                Err(e) => {
+                    warn!(
+                        sender = %sender_for_watcher,
+                        error = %e,
+                        "No DBus proxy for the claim owner watcher; this claim will hold \
+                         until it times out"
+                    );
+                    return;
+                }
             };
 
-            let Ok(mut stream) = dbus.receive_name_owner_changed().await else {
-                return;
+            let mut stream = match dbus.receive_name_owner_changed().await {
+                Ok(stream) => stream,
+                Err(e) => {
+                    warn!(
+                        sender = %sender_for_watcher,
+                        error = %e,
+                        "Could not watch the claim owner; this claim will hold until it \
+                         times out"
+                    );
+                    return;
+                }
             };
 
-            // `receive_name_owner_changed` only installs the match rule once it
-            // resolves, so a sender that lost its owner while we were setting up never
-            // produces a signal and the loop below would wait forever. That leaks the
-            // claim until CLAIM_TIMEOUT_SECS, blocking every later authentication with
-            // "Device already claimed by another interface". Re-check the owner now
-            // that the subscription is live: any disappearance from this point on is
-            // delivered to `stream`, so between the two there is no gap. A name that
-            // cannot be parsed skips the re-check and still gets the stream.
-            if let Ok(watched) = BusName::try_from(sender_for_watcher.clone()) {
-                match dbus.name_has_owner(watched).await {
+            // The match rule only exists once the subscribe above resolves, so a sender
+            // that vanished during setup produces no signal at all. Re-check the owner
+            // now that the stream is live: between the two there is no gap.
+            match BusName::try_from(sender_for_watcher.clone()) {
+                Ok(watched) => match dbus.name_has_owner(watched).await {
                     Ok(false) => {
                         if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
                             info!(
@@ -1944,19 +2020,28 @@ impl AuthDaemon {
                         "Could not re-check the claim owner; a sender that vanished during \
                          setup will hold the claim until it times out"
                     ),
-                }
+                },
+                Err(e) => warn!(
+                    sender = %sender_for_watcher,
+                    error = %e,
+                    "Unparsable claim sender; skipping the owner re-check"
+                ),
             }
 
             while let Some(signal) = stream.next().await {
                 if let Ok(args) = signal.args()
-                    && args.name().as_str() == sender_for_watcher
-                    && args.new_owner().is_none()
+                    && is_vanish_of(
+                        args.name().as_str(),
+                        args.new_owner().as_ref().map(|o| o.as_str()),
+                        &sender_for_watcher,
+                    )
                 {
-                    info!(
-                        sender = %sender_for_watcher,
-                        "Sender vanished, auto-releasing claim"
-                    );
-                    release_claim_epoch(&claim_state, &active_cancel, epoch).await;
+                    if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
+                        info!(
+                            sender = %sender_for_watcher,
+                            "Sender vanished, auto-releasing claim"
+                        );
+                    }
                     break;
                 }
             }

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -63,6 +63,30 @@ fn claim_has_epoch(state: &Option<ClaimState>, epoch: u64) -> bool {
     matches!(state, Some(claim) if claim.epoch == epoch)
 }
 
+/// Drop the claim identified by `epoch` and cancel whatever task it owns.
+///
+/// Matching on the epoch rather than the sender name keeps a late release from
+/// stealing a newer claim: a connection that claims, releases, and claims again reuses
+/// its unique name but never its epoch.
+///
+/// Returns `true` when this call is what dropped the claim.
+async fn release_claim_epoch(
+    claim_state: &Arc<Mutex<Option<ClaimState>>>,
+    active_cancel: &Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    epoch: u64,
+) -> bool {
+    let mut state = claim_state.lock().await;
+    if !claim_has_epoch(&state, epoch) {
+        return false;
+    }
+    *state = None;
+    let mut cancel = active_cancel.lock().await;
+    if let Some(tx) = cancel.take() {
+        let _ = tx.send(());
+    }
+    true
+}
+
 pub struct FaceData {
     pub embedding: Array1<f32>,
     pub liveness_frame: Option<Mat>,
@@ -589,10 +613,13 @@ impl AuthDaemon {
 mod tests {
     use super::{
         AuthDaemon, ClaimState, and_policy_unsatisfiable, auth_streams, claim_has_epoch,
-        eyes_from_kpss, hybrid_auth_passed, pipewire_runtime_update, should_yield_rgb_to_ir,
+        eyes_from_kpss, hybrid_auth_passed, pipewire_runtime_update, release_claim_epoch,
+        should_yield_rgb_to_ir,
     };
     use gaze_core::config::AuthSurface;
     use gaze_core::dbus::{ActiveSession, CaptureStatus};
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, oneshot};
 
     fn session(class: &str) -> ActiveSession {
         ActiveSession {
@@ -690,6 +717,59 @@ mod tests {
 
         assert!(!claim_has_epoch(&state, 1));
         assert!(claim_has_epoch(&state, 2));
+    }
+
+    fn claim_at(epoch: u64) -> Arc<Mutex<Option<ClaimState>>> {
+        Arc::new(Mutex::new(Some(ClaimState {
+            username: "alice".to_string(),
+            sender: ":1.42".to_string(),
+            epoch,
+        })))
+    }
+
+    // The vanish watcher and the claim timeout both release through this path. A
+    // sender that disappears before the watcher subscribes is released by the
+    // post-subscribe owner re-check, which calls exactly this.
+    #[tokio::test]
+    async fn release_clears_and_cancels() {
+        let claim_state = claim_at(7);
+        let (tx, mut rx) = oneshot::channel();
+        let active_cancel = Arc::new(Mutex::new(Some(tx)));
+
+        assert!(release_claim_epoch(&claim_state, &active_cancel, 7).await);
+        assert!(claim_state.lock().await.is_none());
+        // try_recv, not await: the send happens before the call returns, and awaiting a
+        // receiver whose sender is still parked in `active_cancel` would hang instead of
+        // failing if the cancel were ever dropped.
+        assert!(rx.try_recv().is_ok(), "the active task must be cancelled");
+    }
+
+    // A watcher spawned for an earlier claim must not release the claim that replaced
+    // it, otherwise a slow vanish signal would revoke a live authentication.
+    #[tokio::test]
+    async fn stale_epoch_spares_newer_claim() {
+        let claim_state = claim_at(8);
+        let (tx, mut rx) = oneshot::channel();
+        let active_cancel = Arc::new(Mutex::new(Some(tx)));
+
+        assert!(!release_claim_epoch(&claim_state, &active_cancel, 7).await);
+        assert!(claim_has_epoch(&*claim_state.lock().await, 8));
+        assert!(
+            rx.try_recv().is_err(),
+            "the newer claim's task must not be cancelled"
+        );
+    }
+
+    // The owner re-check and the signal handler can both fire for one claim.
+    #[tokio::test]
+    async fn double_release_is_idempotent() {
+        let claim_state = claim_at(9);
+        let (tx, _rx) = oneshot::channel();
+        let active_cancel = Arc::new(Mutex::new(Some(tx)));
+
+        assert!(release_claim_epoch(&claim_state, &active_cancel, 9).await);
+        assert!(!release_claim_epoch(&claim_state, &active_cancel, 9).await);
+        assert!(claim_state.lock().await.is_none());
     }
 
     #[test]
@@ -1812,15 +1892,15 @@ impl AuthDaemon {
         let claim_state = self.claim_state.clone();
         let active_cancel = self.active_cancel.clone();
 
+        let timeout_sender = sender.clone();
         self.rt_handle.spawn(async move {
             tokio::time::sleep(std::time::Duration::from_secs(CLAIM_TIMEOUT_SECS)).await;
-            let mut state = claim_state.lock().await;
-            if claim_has_epoch(&state, epoch) {
-                *state = None;
-                let mut cancel = active_cancel.lock().await;
-                if let Some(tx) = cancel.take() {
-                    let _ = tx.send(());
-                }
+            if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
+                warn!(
+                    sender = %timeout_sender,
+                    timeout_secs = CLAIM_TIMEOUT_SECS,
+                    "Claim timed out and was reclaimed; the client never released it"
+                );
             }
         });
 
@@ -1838,6 +1918,35 @@ impl AuthDaemon {
                 return;
             };
 
+            // `receive_name_owner_changed` only installs the match rule once it
+            // resolves, so a sender that lost its owner while we were setting up never
+            // produces a signal and the loop below would wait forever. That leaks the
+            // claim until CLAIM_TIMEOUT_SECS, blocking every later authentication with
+            // "Device already claimed by another interface". Re-check the owner now
+            // that the subscription is live: any disappearance from this point on is
+            // delivered to `stream`, so between the two there is no gap. A name that
+            // cannot be parsed skips the re-check and still gets the stream.
+            if let Ok(watched) = BusName::try_from(sender_for_watcher.clone()) {
+                match dbus.name_has_owner(watched).await {
+                    Ok(false) => {
+                        if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
+                            info!(
+                                sender = %sender_for_watcher,
+                                "Sender vanished before the watcher subscribed, auto-releasing claim"
+                            );
+                        }
+                        return;
+                    }
+                    Ok(true) => {}
+                    Err(e) => warn!(
+                        sender = %sender_for_watcher,
+                        error = %e,
+                        "Could not re-check the claim owner; a sender that vanished during \
+                         setup will hold the claim until it times out"
+                    ),
+                }
+            }
+
             while let Some(signal) = stream.next().await {
                 if let Ok(args) = signal.args()
                     && args.name().as_str() == sender_for_watcher
@@ -1847,16 +1956,7 @@ impl AuthDaemon {
                         sender = %sender_for_watcher,
                         "Sender vanished, auto-releasing claim"
                     );
-                    let mut state = claim_state.lock().await;
-                    if let Some(claim) = &*state
-                        && claim.sender == sender_for_watcher
-                    {
-                        *state = None;
-                        let mut cancel = active_cancel.lock().await;
-                        if let Some(tx) = cancel.take() {
-                            let _ = tx.send(());
-                        }
-                    }
+                    release_claim_epoch(&claim_state, &active_cancel, epoch).await;
                     break;
                 }
             }


### PR DESCRIPTION
Closes #415

## Summary

- Re-check the claim owner with `name_has_owner` once the `NameOwnerChanged`
  subscription is live, and release the claim if the sender is already gone.
- Log a re-check that errors instead of treating it as still-owned.
- Match releases on the claim epoch rather than the sender name, through one
  `release_claim_epoch` helper shared with the claim timeout.
- Log when `CLAIM_TIMEOUT_SECS` reclaims a claim.
- Add unit tests for the shared release path.

## Why

`Claim` records the claim and then spawns a task that subscribes to
`NameOwnerChanged`. The match rule is only installed once
`receive_name_owner_changed()` resolves, so a sender that loses its owner during
that setup produces no signal. The watcher waits forever on a name that will
never change again and the claim survives until `CLAIM_TIMEOUT_SECS`, refusing
every authentication in between with `Device already claimed by another
interface`.

Re-checking the owner after subscribing closes the window: the check covers
anything that happened before it, the stream covers everything after, and there
is no gap between them. A sender name that fails to parse skips the re-check but
still gets the stream, so it is never worse than the current behaviour.

Matching on the epoch keeps a late watcher from revoking a newer claim. A
connection that claims, releases, and claims again reuses its unique name but
never its epoch, and the second claim has its own watcher.

The timeout path was silent. A leaked claim therefore left no evidence beyond a
missing release, which is easy to misread as an intermittent camera or
recognition fault.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --release --locked --offline -- -D warnings`
- `cargo test --workspace --release --locked --offline`
  - 270 passed
  - 2 TPM hardware tests ignored
  - 0 failed
- `cargo audit`
  - 464 locked dependencies scanned
  - no vulnerabilities reported

The three new tests were mutation-checked: the helper was broken to skip the
epoch guard, to never cancel, and to always report success, and each mutant is
caught.

Verified on the affected hardware. With the subscribe artificially delayed so
the signal is always missed, the re-check releases the claim and the daemon
stays usable; with the re-check removed and the same delay, the daemon
reproduces the reported failure exactly. Forty rapid claim-then-exit cycles
against the patched daemon with no artificial delay released all forty, one of
them via the re-check.
