### PR TITLE
refactor(daemon): watch claim owners with one standing subscription

### DIFF
--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -57,6 +57,12 @@ pub struct ClaimState {
     pub epoch: u64,
 }
 
+/// The single claim the daemon will honour, if any.
+pub type ClaimStateHandle = Arc<Mutex<Option<ClaimState>>>;
+
+/// Cancellation channel for whatever task the current claim owns.
+pub type ActiveCancelHandle = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+
 static CLAIM_EPOCH: AtomicU64 = AtomicU64::new(0);
 
 fn claim_has_epoch(state: &Option<ClaimState>, epoch: u64) -> bool {
@@ -72,8 +78,8 @@ fn is_vanish_of(name: &str, new_owner: Option<&str>, watched: &str) -> bool {
 /// Drop the claim identified by `epoch`, cancel its task, and report whether this call
 /// is what dropped it. Epochs are unique per claim; unique names are not.
 async fn release_claim_epoch(
-    claim_state: &Arc<Mutex<Option<ClaimState>>>,
-    active_cancel: &Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    claim_state: &ClaimStateHandle,
+    active_cancel: &ActiveCancelHandle,
     epoch: u64,
 ) -> bool {
     let mut state = claim_state.lock().await;
@@ -179,8 +185,8 @@ pub struct AuthDaemon {
     pub hybrid_policy: Arc<Mutex<String>>,
     pub abort_if_ssh: Arc<Mutex<bool>>,
     pub abort_if_lid_closed: Arc<Mutex<bool>>,
-    pub claim_state: Arc<Mutex<Option<ClaimState>>>,
-    pub active_cancel: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    pub claim_state: ClaimStateHandle,
+    pub active_cancel: ActiveCancelHandle,
     pub active_extensions: Arc<Mutex<std::collections::HashMap<u32, bool>>>,
     pub resume_pending: Arc<AtomicBool>,
     pub lock_epochs: LockEpochs,
@@ -190,12 +196,6 @@ pub struct AuthDaemon {
 
 /// When each logind session last became locked, keyed by session object path.
 pub type LockEpochs = Arc<Mutex<HashMap<String, std::time::Instant>>>;
-
-/// The single claim the daemon will honour, if any.
-pub type ClaimStateHandle = Arc<Mutex<Option<ClaimState>>>;
-
-/// Cancellation channel for whatever task the current claim owns.
-pub type ActiveCancelHandle = Arc<Mutex<Option<oneshot::Sender<()>>>>;
 
 struct BenchmarkSlot(Arc<AtomicBool>);
 
@@ -619,8 +619,8 @@ impl AuthDaemon {
 #[cfg(test)]
 mod tests {
     use super::{
-        AuthDaemon, ClaimState, and_policy_unsatisfiable, auth_streams, claim_has_epoch,
-        eyes_from_kpss, hybrid_auth_passed, is_vanish_of, pipewire_runtime_update,
+        AuthDaemon, ClaimState, ClaimStateHandle, and_policy_unsatisfiable, auth_streams,
+        claim_has_epoch, eyes_from_kpss, hybrid_auth_passed, is_vanish_of, pipewire_runtime_update,
         release_claim_epoch, should_yield_rgb_to_ir,
     };
     use gaze_core::config::AuthSurface;
@@ -727,7 +727,7 @@ mod tests {
         assert!(claim_has_epoch(&state, 2));
     }
 
-    fn claim_at(epoch: u64) -> Arc<Mutex<Option<ClaimState>>> {
+    fn claim_at(epoch: u64) -> ClaimStateHandle {
         Arc::new(Mutex::new(Some(ClaimState {
             username: "alice".to_string(),
             sender: ":1.42".to_string(),
@@ -1457,40 +1457,34 @@ pub async fn watch_resume(conn: zbus::Connection, resume_pending: Arc<AtomicBool
     }
 }
 
+/// Subscribe to NameOwnerChanged, resolving only once the match rule is installed.
+///
+/// Call this before the daemon requests its well-known name. The subscription has to be
+/// live before any client can claim, or a sender that vanishes in between produces no
+/// signal and strands the claim until `CLAIM_TIMEOUT_SECS`.
+pub async fn subscribe_claim_owners(
+    conn: &zbus::Connection,
+) -> zbus::Result<fdo::NameOwnerChangedStream> {
+    fdo::DBusProxy::new(conn)
+        .await?
+        .receive_name_owner_changed()
+        .await
+}
+
 /// Release the active claim as soon as its owning D-Bus name loses its owner.
 ///
-/// One subscription for the daemon's lifetime, taken before any claim can exist. A
-/// per-claim watcher has to subscribe after recording the claim, which loses the signal
-/// for a sender that disappears during that setup and strands the claim until
-/// `CLAIM_TIMEOUT_SECS`. Subscribing once up front cannot lose it, and does not leave a
-/// task and a signal receiver behind for every claim ever taken.
+/// One subscription for the daemon's lifetime rather than one per claim, which leaves no
+/// task or signal receiver behind for every claim ever taken.
 pub async fn watch_claim_owner(
-    conn: zbus::Connection,
+    mut stream: fdo::NameOwnerChangedStream,
     claim_state: ClaimStateHandle,
     active_cancel: ActiveCancelHandle,
 ) {
-    let dbus = match fdo::DBusProxy::new(&conn).await {
-        Ok(dbus) => dbus,
-        Err(e) => {
-            warn!("Failed to create DBus proxy, claims will only be released on timeout: {e}");
-            return;
-        }
-    };
-
-    let mut stream = match dbus.receive_name_owner_changed().await {
-        Ok(stream) => stream,
-        Err(e) => {
-            warn!(
-                "Failed to subscribe to NameOwnerChanged, claims will only be released on timeout: {e}"
-            );
-            return;
-        }
-    };
-
     while let Some(signal) = stream.next().await {
         let Ok(args) = signal.args() else {
             continue;
         };
+
         let name = args.name().as_str();
         let epoch = {
             let state = claim_state.lock().await;
@@ -1516,6 +1510,8 @@ pub async fn watch_claim_owner(
             info!(sender = %name, "Sender vanished, auto-releasing claim");
         }
     }
+
+    error!("NameOwnerChanged stream ended; claims will only be released on timeout");
 }
 
 async fn session_properties_stream(conn: &zbus::Connection) -> zbus::Result<zbus::MessageStream> {
@@ -2039,17 +2035,33 @@ impl AuthDaemon {
         let conn = conn.clone();
         let sender_for_check = sender.clone();
 
-        // `watch_claim_owner` subscribed before this claim existed, so it cannot miss a
-        // disappearance from here on. It can however have already handled the vanish
-        // while this claim was still being authorized and recorded, in which case it
-        // found no claim to release. Confirm the owner once, now that there is one. A
-        // name that cannot be parsed skips the confirmation and relies on the timeout.
+        // The watcher cannot miss a disappearance from here on, but it may already have
+        // handled this one while the claim was still being authorized, finding nothing to
+        // release. Confirm the owner once, now that there is a claim to drop.
         self.rt_handle.spawn(async move {
-            let Ok(dbus) = fdo::DBusProxy::new(&conn).await else {
-                return;
+            let dbus = match fdo::DBusProxy::new(&conn).await {
+                Ok(dbus) => dbus,
+                Err(e) => {
+                    warn!(
+                        sender = %sender_for_check,
+                        error = %e,
+                        "No DBus proxy to confirm the claim owner; this claim will hold \
+                         until it times out"
+                    );
+                    return;
+                }
             };
-            let Ok(watched) = BusName::try_from(sender_for_check.clone()) else {
-                return;
+
+            let watched = match BusName::try_from(sender_for_check.clone()) {
+                Ok(watched) => watched,
+                Err(e) => {
+                    warn!(
+                        sender = %sender_for_check,
+                        error = %e,
+                        "Unparsable claim sender; skipping the owner confirmation"
+                    );
+                    return;
+                }
             };
 
             match dbus.name_has_owner(watched).await {

--- a/gaze/src/daemon.rs
+++ b/gaze/src/daemon.rs
@@ -191,6 +191,12 @@ pub struct AuthDaemon {
 /// When each logind session last became locked, keyed by session object path.
 pub type LockEpochs = Arc<Mutex<HashMap<String, std::time::Instant>>>;
 
+/// The single claim the daemon will honour, if any.
+pub type ClaimStateHandle = Arc<Mutex<Option<ClaimState>>>;
+
+/// Cancellation channel for whatever task the current claim owns.
+pub type ActiveCancelHandle = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+
 struct BenchmarkSlot(Arc<AtomicBool>);
 
 impl BenchmarkSlot {
@@ -1451,6 +1457,67 @@ pub async fn watch_resume(conn: zbus::Connection, resume_pending: Arc<AtomicBool
     }
 }
 
+/// Release the active claim as soon as its owning D-Bus name loses its owner.
+///
+/// One subscription for the daemon's lifetime, taken before any claim can exist. A
+/// per-claim watcher has to subscribe after recording the claim, which loses the signal
+/// for a sender that disappears during that setup and strands the claim until
+/// `CLAIM_TIMEOUT_SECS`. Subscribing once up front cannot lose it, and does not leave a
+/// task and a signal receiver behind for every claim ever taken.
+pub async fn watch_claim_owner(
+    conn: zbus::Connection,
+    claim_state: ClaimStateHandle,
+    active_cancel: ActiveCancelHandle,
+) {
+    let dbus = match fdo::DBusProxy::new(&conn).await {
+        Ok(dbus) => dbus,
+        Err(e) => {
+            warn!("Failed to create DBus proxy, claims will only be released on timeout: {e}");
+            return;
+        }
+    };
+
+    let mut stream = match dbus.receive_name_owner_changed().await {
+        Ok(stream) => stream,
+        Err(e) => {
+            warn!(
+                "Failed to subscribe to NameOwnerChanged, claims will only be released on timeout: {e}"
+            );
+            return;
+        }
+    };
+
+    while let Some(signal) = stream.next().await {
+        let Ok(args) = signal.args() else {
+            continue;
+        };
+        let name = args.name().as_str();
+        let epoch = {
+            let state = claim_state.lock().await;
+            match &*state {
+                Some(claim)
+                    if is_vanish_of(
+                        name,
+                        args.new_owner().as_ref().map(|o| o.as_str()),
+                        &claim.sender,
+                    ) =>
+                {
+                    Some(claim.epoch)
+                }
+                _ => None,
+            }
+        };
+        let Some(epoch) = epoch else {
+            continue;
+        };
+
+        let name = name.to_string();
+        if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
+            info!(sender = %name, "Sender vanished, auto-releasing claim");
+        }
+    }
+}
+
 async fn session_properties_stream(conn: &zbus::Connection) -> zbus::Result<zbus::MessageStream> {
     let rule = zbus::MatchRule::builder()
         .msg_type(zbus::message::Type::Signal)
@@ -1970,80 +2037,37 @@ impl AuthDaemon {
         let claim_state = self.claim_state.clone();
         let active_cancel = self.active_cancel.clone();
         let conn = conn.clone();
-        let sender_for_watcher = sender.clone();
+        let sender_for_check = sender.clone();
 
+        // `watch_claim_owner` subscribed before this claim existed, so it cannot miss a
+        // disappearance from here on. It can however have already handled the vanish
+        // while this claim was still being authorized and recorded, in which case it
+        // found no claim to release. Confirm the owner once, now that there is one. A
+        // name that cannot be parsed skips the confirmation and relies on the timeout.
         self.rt_handle.spawn(async move {
-            let dbus = match fdo::DBusProxy::new(&conn).await {
-                Ok(dbus) => dbus,
-                Err(e) => {
-                    warn!(
-                        sender = %sender_for_watcher,
-                        error = %e,
-                        "No DBus proxy for the claim owner watcher; this claim will hold \
-                         until it times out"
-                    );
-                    return;
-                }
+            let Ok(dbus) = fdo::DBusProxy::new(&conn).await else {
+                return;
+            };
+            let Ok(watched) = BusName::try_from(sender_for_check.clone()) else {
+                return;
             };
 
-            let mut stream = match dbus.receive_name_owner_changed().await {
-                Ok(stream) => stream,
-                Err(e) => {
-                    warn!(
-                        sender = %sender_for_watcher,
-                        error = %e,
-                        "Could not watch the claim owner; this claim will hold until it \
-                         times out"
-                    );
-                    return;
-                }
-            };
-
-            // The match rule only exists once the subscribe above resolves, so a sender
-            // that vanished during setup produces no signal at all. Re-check the owner
-            // now that the stream is live: between the two there is no gap.
-            match BusName::try_from(sender_for_watcher.clone()) {
-                Ok(watched) => match dbus.name_has_owner(watched).await {
-                    Ok(false) => {
-                        if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
-                            info!(
-                                sender = %sender_for_watcher,
-                                "Sender vanished before the watcher subscribed, auto-releasing claim"
-                            );
-                        }
-                        return;
-                    }
-                    Ok(true) => {}
-                    Err(e) => warn!(
-                        sender = %sender_for_watcher,
-                        error = %e,
-                        "Could not re-check the claim owner; a sender that vanished during \
-                         setup will hold the claim until it times out"
-                    ),
-                },
-                Err(e) => warn!(
-                    sender = %sender_for_watcher,
-                    error = %e,
-                    "Unparsable claim sender; skipping the owner re-check"
-                ),
-            }
-
-            while let Some(signal) = stream.next().await {
-                if let Ok(args) = signal.args()
-                    && is_vanish_of(
-                        args.name().as_str(),
-                        args.new_owner().as_ref().map(|o| o.as_str()),
-                        &sender_for_watcher,
-                    )
-                {
+            match dbus.name_has_owner(watched).await {
+                Ok(false) => {
                     if release_claim_epoch(&claim_state, &active_cancel, epoch).await {
                         info!(
-                            sender = %sender_for_watcher,
-                            "Sender vanished, auto-releasing claim"
+                            sender = %sender_for_check,
+                            "Sender vanished while claiming, auto-releasing claim"
                         );
                     }
-                    break;
                 }
+                Ok(true) => {}
+                Err(e) => warn!(
+                    sender = %sender_for_check,
+                    error = %e,
+                    "Could not confirm the claim owner; a sender that vanished while \
+                     claiming will hold the claim until it times out"
+                ),
             }
         });
 

--- a/gaze/src/main.rs
+++ b/gaze/src/main.rs
@@ -163,6 +163,8 @@ async fn main() -> anyhow::Result<()> {
 
     let resume_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let lock_epochs: daemon::LockEpochs = Arc::new(Mutex::new(std::collections::HashMap::new()));
+    let claim_state: daemon::ClaimStateHandle = Arc::new(Mutex::new(None));
+    let active_cancel: daemon::ActiveCancelHandle = Arc::new(Mutex::new(None));
 
     let daemon = AuthDaemon {
         detector: Arc::new(std::sync::Mutex::new(detector)),
@@ -180,8 +182,8 @@ async fn main() -> anyhow::Result<()> {
         hybrid_policy: Arc::new(Mutex::new(security.hybrid_policy().to_string())),
         abort_if_ssh: Arc::new(Mutex::new(config.auth.abort_if_ssh)),
         abort_if_lid_closed: Arc::new(Mutex::new(config.auth.abort_if_lid_closed)),
-        claim_state: Arc::new(Mutex::new(None)),
-        active_cancel: Arc::new(Mutex::new(None)),
+        claim_state: claim_state.clone(),
+        active_cancel: active_cancel.clone(),
         active_extensions: Arc::new(Mutex::new(std::collections::HashMap::new())),
         resume_pending: resume_pending.clone(),
         lock_epochs: lock_epochs.clone(),
@@ -199,6 +201,11 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(daemon::watch_resume(conn.clone(), resume_pending));
     tokio::spawn(daemon::watch_session_locks(conn.clone(), lock_epochs));
+    tokio::spawn(daemon::watch_claim_owner(
+        conn.clone(),
+        claim_state,
+        active_cancel,
+    ));
 
     info!("Gaze Daemon listening on System Bus");
     std::future::pending::<()>().await;

--- a/gaze/src/main.rs
+++ b/gaze/src/main.rs
@@ -194,18 +194,25 @@ async fn main() -> anyhow::Result<()> {
     info!(elapsed = ?t_load.elapsed(), "Models & user DB loaded");
 
     let conn = Builder::system()?
-        .name("com.gundulabs.Gaze")?
         .serve_at("/com/gundulabs/Gaze", daemon)?
         .build()
         .await?;
 
     tokio::spawn(daemon::watch_resume(conn.clone(), resume_pending));
     tokio::spawn(daemon::watch_session_locks(conn.clone(), lock_epochs));
+
+    // Subscribe before the well-known name exists: until it does no client can claim, so
+    // this is what makes "the watcher cannot miss a disappearance" true rather than a
+    // race the daemon usually wins. A failure here is fatal by design, so systemd
+    // restarts us instead of running on with claims that only the timeout can release.
+    let claim_owners = daemon::subscribe_claim_owners(&conn).await?;
     tokio::spawn(daemon::watch_claim_owner(
-        conn.clone(),
+        claim_owners,
         claim_state,
         active_cancel,
     ));
+
+    conn.request_name("com.gundulabs.Gaze").await?;
 
     info!("Gaze Daemon listening on System Bus");
     std::future::pending::<()>().await;


### PR DESCRIPTION
Stacked on #416 — it contains that commit too until #416 merges, after which this
diff reduces to its own commit. Review #416 first.

## Summary

- Replace the per-claim `NameOwnerChanged` watcher with a single `watch_claim_owner`
  task subscribed once at daemon startup, alongside the existing `watch_resume` and
  `watch_session_locks` watchers.
- Keep the claim-time owner confirmation from #416 for the case where a vanish is
  processed before the claim is recorded.

## Why

Each `Claim` spawned its own watcher, and those watchers outlive the claim they were
spawned for. `release()` cancels the active verification task, but nothing stops the
watcher — its only exit is observing its own sender vanish. A client that claims
repeatedly on one connection accumulates a live task and a signal receiver per claim,
every one of them woken by every `NameOwnerChanged` on the bus.

Measured on the affected machine, 600 claim/release cycles on a single connection:

```text
claims:           600
releases:         600
sender vanished:  600     <- one per surviving watcher, all at once on disconnect
```

Nothing bounds this except the client's connection lifetime. A lock screen that claims
on every unlock attempt carries one per attempt for as long as its connection lives.

Subscribing once at startup gives one task and one receiver regardless of claim count.
The same 600 cycles plus one held claim now produce exactly one release:

```text
claims:           601
releases:         600
sender vanished:  1
```

It also removes the window #416 patches around, rather than compensating for it: a
subscription taken at startup cannot be installed later than a claim made afterwards.
The claim-time confirmation is kept, because a vanish can still be processed in the gap
between the caller checks passing and the claim being recorded, but it no longer carries
the whole guarantee.

Note this is not a bus-level concern. zbus refcounts identical match rules, so all those
watchers shared one `AddMatch`; the cost is in-process tasks and wakeups, not
`max_match_rules_per_connection`.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --release --locked --offline -- -D warnings`
- `cargo test --workspace --release --locked --offline`
  - 270 passed
  - 2 TPM hardware tests ignored
  - 0 failed

Verified on the affected hardware against the refactored daemon:

- 600 claim/release cycles plus one held claim on a single connection produce exactly
  one `Sender vanished` line, and the held claim is released.
- The original leak reproducer (async `Claim`, vanish before the reply is processed)
  followed by 40 rapid claim-then-exit cycles: 42 claims, 42 released across
  `Release()` and the standing watcher, 0 leaked, no warnings.

In those runs the standing watcher handled every disappearance and the claim-time
confirmation never fired, which is expected given how much smaller its window now is —
but it does mean that path is not exercised by these tests.
